### PR TITLE
rename snap map url

### DIFF
--- a/.rosinstall
+++ b/.rosinstall
@@ -22,8 +22,8 @@
 - svn:
     uri: https://svn.code.sf.net/p/tum-ros-pkg/code/perception/
     local-name: tum-ros-pkg/perception
-- svn:
-    uri: https://svn.code.sf.net/p/tum-ros-pkg/code/highlevel/SnapMapICP
+- git:
+    uri: https://github.com/code-iai/SnapMapICP.git
     local-name: tum-ros-pkg/highlevel/SnapMapICP
 - git:
     uri: https://github.com/knowrob/knowrob.git


### PR DESCRIPTION
Use git uri instread of svn uri. #3
