### PR TITLE
change the threshold to apply snapmap

### DIFF
--- a/detect_cans_in_fridge_201202/launch/startup.launch
+++ b/detect_cans_in_fridge_201202/launch/startup.launch
@@ -53,6 +53,7 @@
 
   <!-- ICP matching between map and base scan -->
   <param name="SnapMapICP/age_threshold" value="2.0"/>
+  <param name="SnapMapICP/icp_inlier_threshold" value="0.78" />
   <node pkg="SnapMapICP" type="SnapMapICP" name="tum_SnapMapICP"
         output="screen" machine="c2"/>
 


### PR DESCRIPTION
default threshold for icp_inliers is 0.88 and now we have 0.78
