### PR TITLE
Add setupfile and add valve rotation

### DIFF
--- a/jsk_2014_06_pr2_drcbox/euslisp/setup.l
+++ b/jsk_2014_06_pr2_drcbox/euslisp/setup.l
@@ -17,26 +17,61 @@
   (send *drcbox* :locate base-pos :world)
   (objects (list *robot* *drcbox*)))
 
+(defun send-reach-target
+  (move-target-list
+   root-relative-target-coords-list ;; list of target-coords ;; target-coords is relative to root
+   send-time ;; :angle-vector time [ms]
+   alpha ;; ratio from move-target to target-coords in [0.0, 1.0] ;; 0.0 = move-target, 1.0 = target-coords
+   &key (robot) (real t))
+  (let* ((target-coords-list ;; world target-coords list
+          (mapcar #'(lambda (tc)
+                      (send (send (car (send robot :links)) :copy-worldcoords) :transform tc))
+                  root-relative-target-coords-list))
+         (ret
+          (send robot :inverse-kinematics
+                (mapcar #'(lambda (mt tc)
+                            (make-coords :pos (send (midcoords alpha mt tc) :worldpos)
+                                         :rot (send tc :worldrot)))
+                        move-target-list target-coords-list)
+                :move-target move-target-list
+                :link-list (mapcar #'(lambda (mt) (send robot :link-list (send mt :parent))) move-target-list)
+                :look-at-target t
+                :debug-view :no-message
+                )))
+    (if (and ret real)
+        (send *ri* :angle-vector (send robot :angle-vector) send-time))
+    ))
+
+(defun send-way-point
+  (move-target-list
+   root-relative-target-coords-list-trajectory ;; list of (list target-coords-list-0 ... target-coords-list-n)
+   send-time-list ;; list of (list time-0 ... time-n)
+   &key (robot) (real t))
+  (let* ((target-coords-list-trajectory ;; world target-coords list
+          (mapcar #'(lambda (tc)
+                      (send (send (car (send robot :links)) :copy-worldcoords) :transform tc))
+                  root-relative-target-coords-list-trajectory))
+         (ret
+          (mapcar #'(lambda (target-coords-list)
+                      (send robot :inverse-kinematics
+                            target-coords-list
+                            :move-target move-target-list
+                            :link-list (mapcar #'(lambda (mt) (send robot :link-list (send mt :parent))) move-target-list)
+                            ))
+                  target-coords-list-trajectory)))
+    (if (and (every #'identity ret) real)
+        (send *ri* :angle-vector-sequence ret send-time-list))
+    ))
+
+
+
+
 (warn "(gen-motion-valve-rotation :object \"drcbox-valve-large\" :start -30 :end 30 :interval 10 :time-interval 1000)~%")
 (defun gen-motion-valve-rotation (&key (object "drcbox-valve-large") (start -30) (end 30) (interval 10) (time-interval 1000))
   (labels ((get-target
             (valve deg)
             (send (send valve :joint :crank-joint) :joint-angle deg)
             (send (send valve :handle-valve-handle) :copy-worldcoords))
-           (solve-ik
-            (robot move-target-list root-relative-target-coords-list)
-            (send robot :inverse-kinematics
-                  (mapcar #'(lambda (tc)
-                              (send (send (car (send robot :links)) :copy-worldcoords)
-                                    :transform tc))
-                          root-relative-target-coords-list)
-                  :move-target move-target-list
-                  :link-list (mapcar
-                              #'(lambda (mt) (send robot :link-list (send mt :parent)))
-                              move-target-list)
-                  :look-at-target t
-                  :debug-view :no-message
-                  ))
            (make-deg-list
             (start end interval)
             (let (tmp)
@@ -49,10 +84,14 @@
           (tm 0)
           ret)
       (dolist (i deg-list)
-        (solve-ik *robot*
-                  (list (send *robot* :rarm :end-coords))
-                  (list (send (car (send *robot* :links))
-                              :transformation (get-target (send *drcbox* :object object) i))))
+        (send-reach-target
+         (list (send *robot* :rarm :end-coords))
+         (list (send (car (send *robot* :links))
+                     :transformation (get-target (send *drcbox* :object object) i)))
+         time-interval
+         1.0
+         :robot *robot*
+         :real nil)
         (push (list :angle-vector (send *robot* :angle-vector)
                     :root-coords (send (car (send *robot* :links)) :copy-worldcoords)
                     :contact-state '(:rarm)


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_demos/pull/25 ということなので，drcboxとpr2を表示するセットアップファイルを書きました．

``` lisp
(setup-drcbox :base-pos #f(1200 0 0))
```

また， https://github.com/jsk-ros-pkg/jsk_demos/issues/26#issuecomment-46970408 ではドリルからsetup.lに実装していく，ということでしたが，
既にbipedロボット用にバルブを開けるプログラムを作っていたので，それを台車ロボット用に移植しておきました．
これは余計でしょうか？余計でしたらすみません．

https://github.com/jsk-ros-pkg/jsk_demos/issues/26#issuecomment-46997508 にある`send-reach-target`と`send-way-point`も加え，バルブを開けるプログラムは`send-reach-target`を使って書いてあります．

``` lisp
(gen-motion-valve-rotation :object "drcbox-valve-large" :start -30 :end 30 :interval 10 :time-interval 1000)
(gen-motion-valve-rotation :object "drcbox-valve-bar" :start -30 :end 0 :interval 10 :time-interval 1000)
```

![screenshot_from_2014-06-25 03 32 21](https://cloud.githubusercontent.com/assets/4509039/3376473/56a36e04-fbd5-11e3-9cf8-e5bb577e59a7.png)
![screenshot_from_2014-06-25 03 33 04](https://cloud.githubusercontent.com/assets/4509039/3376476/56a5adb8-fbd5-11e3-8c24-e157c10d1d29.png)
![screenshot_from_2014-06-25 03 33 45](https://cloud.githubusercontent.com/assets/4509039/3376474/56a43f78-fbd5-11e3-865f-eea8d4ac26ef.png)
![screenshot_from_2014-06-25 03 34 30](https://cloud.githubusercontent.com/assets/4509039/3376475/56a5956c-fbd5-11e3-9763-62dfdfafb39e.png)
