### PR TITLE
add error message line and prevent many warning message if the target-tf...

### DIFF
--- a/jsk_maps/tools/publish_spot.l
+++ b/jsk_maps/tools/publish_spot.l
@@ -33,7 +33,7 @@
         (header (instance std_msgs::header :init :stamp (ros::time-now) :frame_id "/map"))
         (colors (make-color-list (length (send *scene* :spots))))
         (id 0) c n msgs current-map-id current-map-coords)
-    (if (equal "" *map-selected*) (progn (ros::ros-error "map-selected is empty! please set /map_tf_mux/selected in publish_spot.l") (return-from pub-spot)))
+    (if (equal "" *map-selected*) (progn (ros::ros-error "[jsk_maps/publish_spot.l] map-selected is empty! please publish /map_tf_mux/selected") (return-from pub-spot)))
     (setq current-map-id (string-right-trim "_" (string-right-trim "tf" *map-selected*))) ;; remove _tf
     (when (send  *tf-listener* :wait-for-transform "/world" current-map-id (ros::time-now) 1)
       (setq current-map-coords (send *tf-listener* :lookup-transform "/world" current-map-id (ros::time-now)))) ;; resolve /world /eng/7f


### PR DESCRIPTION
... is empty

prevent like below error

```
Warning: Invalid argument passed to canTransform argument source_frame in tf2 frame_ids cannot be empty
         at line 122 in /tmp/buildd/ros-hydro-tf2-0.4.11-0precise-20140617-0510/src/buffer_core.cpp
Warning: Invalid argument passed to canTransform argument source_frame in tf2 frame_ids cannot be empty
         at line 122 in /tmp/buildd/ros-hydro-tf2-0.4.11-0precise-20140617-0510/src/buffer_core.cpp
Warning: Invalid argument passed to canTransform argument source_frame in tf2 frame_ids cannot be empty
         at line 122 in /tmp/buildd/ros-hydro-tf2-0.4.11-0precise-20140617-0510/src/buffer_core.cpp
Warning: Invalid argument passed to canTransform argument source_frame in tf2 frame_ids cannot be empty
         at line 122 in /tmp/buildd/ros-hydro-tf2-0.4.11-0precise-20140617-0510/src/buffer_core.cpp
Warning: Invalid argument passed to canTransform argument source_frame in tf2 frame_ids cannot be empty
         at line 122 in /tmp/buildd/ros-hydro-tf2-0.4.11-0precise-20140617-0510/src/buffer_core.cpp
Warning: Invalid argument passed to canTransform argument source_frame in tf2 frame_ids cannot be empty
         at line 122 in /tmp/buildd/ros-hydro-tf2-0.4.11-0precise-20140617-0510/src/buffer_core.cpp
Warning: Invalid argument passed to canTransform argument source_frame in tf2 frame_ids cannot be empty
         at line 122 in /tmp/buildd/ros-hydro-tf2-0.4.11-0precise-20140617-0510/src/buffer_core.cpp
Warning: Invalid argument passed to canTransform argument source_frame in tf2 frame_ids cannot be empty
         at line 122 in /tmp/buildd/ros-hydro-tf2-0.4.11-0precise-20140617-0510/src/buffer_core.cpp
Warning: Invalid argument passed to canTransform argument source_frame in tf2 frame_ids cannot be empty
         at line 122 in /tmp/buildd/ros-hydro-tf2-0.4.11-0precise-20140617-0510/src/buffer_core.cpp
Warning: Invalid argument passed to canTransform argument source_frame in tf2 frame_ids cannot be empty
         at line 122 in /tmp/buildd/ros-hydro-tf2-0.4.11-0precise-20140617-0510/src/buffer_core.cpp
Warning: Invalid argument passed to canTransform argument source_frame in tf2 frame_ids cannot be empty
         at line 122 in /tmp/buildd/ros-hydro-tf2-0.4.11-0precise-20140617-0510/src/buffer_core.cpp
Warning: Invalid argument passed to canTransform argument source_frame in tf2 frame_ids cannot be empty
         at line 122 in /tmp/buildd/ros-hydro-tf2-0.4.11-0precise-20140617-0510/src/buffer_core.cpp
Warning: Invalid argument passed to canTransform argument source_frame in tf2 frame_ids cannot be empty
         at line 122 in /tmp/buildd/ros-hydro-tf2-0.4.11-0precise-20140617-0510/src/buffer_core.cpp
Warning: Invalid argument passed to canTransform argument source_frame in tf2 frame_ids cannot be empty
         at line 122 in /tmp/buildd/ros-hydro-tf2-0.4.11-0precise-20140617-0510/src/buffer_core.cpp
Warning: Invalid argument passed to canTransform argument source_frame in tf2 frame_ids cannot be empty
         at line 122 in /tmp/buildd/ros-hydro-tf2-0.4.11-0precise-20140617-0510/src/buffer_core.cpp
Warning: Invalid argument passed to canTransform argument source_frame in tf2 frame_ids cannot be empty
         at line 122 in /tmp/buildd/ros-hydro-tf2-0.4.11-0precise-20140617-0510/src/buffer_core.cpp
Warning: Invalid argument passed to canTransform argument source_frame in tf2 frame_ids cannot be empty
         at line 122 in /tmp/buildd/ros-hydro-tf2-0.4.11-0precise-20140617-0510/src/buffer_core.cpp
Warning: Invalid argument passed to canTransform argument source_frame in tf2 frame_ids cannot be empty

```
