### PR TITLE
added axial-restraint interface for ik

### DIFF
--- a/jsk_2015_06_hrp_drc/drc_task_common/include/drc_task_common/manipulation_data_helpers.h
+++ b/jsk_2015_06_hrp_drc/drc_task_common/include/drc_task_common/manipulation_data_helpers.h
@@ -47,7 +47,7 @@ bool write_marker(int file_index, ManipulationData &imk);
 std::vector<visualization_msgs::Marker> make_grab(visualization_msgs::InteractiveMarker &int_marker);
 visualization_msgs::Marker make_box(float s_x, float s_y, float s_z, float r, float g, float b, float x, float y, float z);
 visualization_msgs::Marker make_circle(visualization_msgs::InteractiveMarker &msg );
-visualization_msgs::Marker make_arrow(visualization_msgs::InteractiveMarker &msg );
+ visualization_msgs::Marker make_arrow(visualization_msgs::InteractiveMarker &msg, float arrow_offset_x_pos=-0.11, float r=0.8, float g=0.8, float b=0.8);
 
 
 tf::Transform pose_to_tf(geometry_msgs::Pose pose);

--- a/jsk_2015_06_hrp_drc/drc_task_common/src/drc_task_common/manipulation_data_helpers.cpp
+++ b/jsk_2015_06_hrp_drc/drc_task_common/src/drc_task_common/manipulation_data_helpers.cpp
@@ -178,14 +178,14 @@ visualization_msgs::Marker make_circle(visualization_msgs::InteractiveMarker &ms
   marker.pose.orientation.w = 1.0;
   return marker;
 }
-visualization_msgs::Marker make_arrow(visualization_msgs::InteractiveMarker &msg ){
+visualization_msgs::Marker make_arrow(visualization_msgs::InteractiveMarker &msg, float arrow_offset_x_pos, float r, float g, float b){
   visualization_msgs::Marker marker;
   marker.type = Marker::ARROW;
   marker.scale.x = 0.11;
   marker.scale.y = 0.04;
   marker.scale.z = 0.04;
-  marker.color.r = .8; marker.color.g = .8; marker.color.b = .8; marker.color.a = 1.0;
-  marker.pose.position.x = -.11;
+  marker.color.r = r; marker.color.g = g; marker.color.b = b; marker.color.a = 1.0;
+  marker.pose.position.x = arrow_offset_x_pos;
   marker.pose.position.y = 0.0;
   marker.pose.position.z = 0.0;
   marker.pose.orientation.w = 1.0;


### PR DESCRIPTION
IKを、ドリルの先の軸を元に解くという話があったので、そのインターフェイスを
追加しました。manipulation_data_serverにあった既存のマーカーと同じような使い方で、
ポイントを選ぶと軸の矢印が出てきます。

![axial_restraint](https://cloud.githubusercontent.com/assets/7259700/5535857/944dd33c-8aca-11e4-9395-57c29e0870bd.png)
![axial_restraint_2](https://cloud.githubusercontent.com/assets/7259700/5535863/a827cf66-8aca-11e4-9944-bb50f64b58a0.png)
