### PR TITLE
Add axial restraint ik

### DIFF
--- a/jsk_2015_06_hrp_drc/drc_task_common/euslisp/request-ik-from-marker.l
+++ b/jsk_2015_06_hrp_drc/drc_task_common/euslisp/request-ik-from-marker.l
@@ -748,11 +748,21 @@
        (*ik-result*
         (dotimes (i (length *ik-result*))
           (mapcar #'(lambda (j a) (send j :joint-angle a)) (send *robot* :joint-list) (elt *ik-result* i))
-          (send *ri* :angle-vector (send *robot* :angle-vector) (/ (float int-time) (length *ik-result*)))
-          (cond ((= i (- (length *ik-result*) 1))
-                 (send *ri* :wait-interpolation))
-                (t
-                 (unix::usleep (round (* (* (/ (float int-time) (length *ik-result*)) 1000) 0.8)))))
+          (cond
+           ;; interpolation mode and first time ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+           ((and (= i 0) (> (length *ik-result*) 1))
+            (send *ri* :angle-vector (send *robot* :angle-vector) (float int-time))
+            (unix::usleep (round (* (* int-time 1000) 0.8)))
+            )
+           ;; original ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+           (t
+            (send *ri* :angle-vector (send *robot* :angle-vector) (/ (float int-time) (length *ik-result*)))
+            (cond ((= i (- (length *ik-result*) 1))
+                   (send *ri* :wait-interpolation))
+                  (t
+                   (unix::usleep (round (* (* (/ (float int-time) (length *ik-result*)) 1000) 0.8)))))
+            )
+           )
           ))
        (t
         (send *ri* :angle-vector (send *robot* :angle-vector) int-time)


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_demos/pull/103
で作ったUIに対して，ロボットを動かすコードを書きました．
６自由度拘束するよりも，広い範囲でIKが解けることが確認出来ました．　

実機で実験をしていたときに，リーチングが早すぎてバランスを崩したので，
b727e86 で @mmurooka さんと，リーチングの速さを遅くするように変更しました．
