### PR TITLE
Fix typo in drc_com_common : rosbuid -> rosbuild

### DIFF
--- a/jsk_2015_06_hrp_drc/drc_com_common/package.xml
+++ b/jsk_2015_06_hrp_drc/drc_com_common/package.xml
@@ -9,13 +9,13 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>mk</build_depend>
-  <build_depend>rosbuid</build_depend>
+  <build_depend>rosbuild</build_depend>
   <build_depend>roseus</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>roslib</build_depend>
   <build_depend>rospy</build_depend>
   <run_depend>mk</run_depend>
-  <run_depend>rosbuid</run_depend>
+  <run_depend>rosbuild</run_depend>
   <run_depend>roseus</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>roslib</run_depend>


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_demos/commit/ea19aea260bfb02fa370094bf2781eeb4eb68a70#commitcomment-9434538