### PR TITLE
add gun_drill downloader

### DIFF
--- a/jsk_2015_06_hrp_drc/drc_task_common/CMakeLists.txt
+++ b/jsk_2015_06_hrp_drc/drc_task_common/CMakeLists.txt
@@ -73,8 +73,16 @@ catkin_download_test_data(drill_pcd
 catkin_download_test_data(drill_full_pcd
   http://www.jsk.t.u-tokyo.ac.jp/~ueda/dataset/2015/02/drill_full.pcd
   DESTINATION ${PROJECT_SOURCE_DIR}/pcds)
+execute_process(
+  COMMAND mkdir -p ${PROJECT_SOURCE_DIR}/models)
+catkin_download_test_data(gun_drill_dae
+  http://www.jsk.t.u-tokyo.ac.jp/~ohara/dataset/2015/03/gun_drill.dae
+  DESTINATION ${PROJECT_SOURCE_DIR}/models)
+catkin_download_test_data(gun_drill_jpg
+  http://www.jsk.t.u-tokyo.ac.jp/~ohara/dataset/2015/03/gun_drill_color.jpg
+  DESTINATION ${PROJECT_SOURCE_DIR}/models)
 add_custom_target(all_drc_task_common_downloads ALL DEPENDS
-  drill_pcd drill_full_pcd)
+  drill_pcd drill_full_pcd gun_drill_dae gun_drill_jpg)
 
 install(TARGETS
   ${PROJECT_NAME}


### PR DESCRIPTION
![drill](https://cloud.githubusercontent.com/assets/7259700/6670607/f9bb2238-cc42-11e4-834c-682e40ac6215.png)

drill のモデルをmake時にdownload するスクリプトを加えました。
写真は、.daeをインタラクティブマーカーにして、実世界の点群と合わせてます。