### PR TITLE
[drc_task_common] add function to wait interpolation in ocs

### DIFF
--- a/jsk_2015_06_hrp_drc/drc_task_common/euslisp/fc-executive.l
+++ b/jsk_2015_06_hrp_drc/drc_task_common/euslisp/fc-executive.l
@@ -741,6 +741,7 @@
        (send smachine :go-to :executing-angle-vector)
        (format t "angle-vector ~A ~A~%" av time)
        (send *ri* :angle-vector av time)
+       (send *ri* :wait-interpolation)
        )
      (let ((msg (instance drc_com_common::FC2OCSSmall :init)))
        (send msg :type drc_com_common::FC2OCSSmall::*ANGLE_VECTOR_FINISHED*)

--- a/jsk_2015_06_hrp_drc/drc_task_common/euslisp/ocs-executive.l
+++ b/jsk_2015_06_hrp_drc/drc_task_common/euslisp/ocs-executive.l
@@ -883,6 +883,7 @@
       (send smachine :go-to :initial)
       ))
   (:angle-vector-finished-callback (msg)
+      (send-angle-vector-finished-service)
    )
   )
 

--- a/jsk_2015_06_hrp_drc/drc_task_common/euslisp/request-ik-from-marker.l
+++ b/jsk_2015_06_hrp_drc/drc_task_common/euslisp/request-ik-from-marker.l
@@ -643,8 +643,8 @@
               (cond (*use-robot-interface-flag*
                      (send *ri* :wait-interpolation))
                     (t
-                     (unix::usleep (round (* (/ (float int-time) (length *ik-result*)) 1000)))
-                     ;;(wait-interpolation-from-ocs)
+                     ;;(unix::usleep (round (* (/ (float int-time) (length *ik-result*)) 1000)))
+                     (wait-interpolation-from-ocs)
                      ))
               )
 	     (t

--- a/jsk_2015_06_hrp_drc/drc_task_common/euslisp/robot-util.l
+++ b/jsk_2015_06_hrp_drc/drc_task_common/euslisp/robot-util.l
@@ -88,6 +88,23 @@
 
 (defun wait-interpolation-from-ocs
   ()
+  (unless (boundp '*wait-interpolation-from-ocs-inited*)
+    (ros::advertise-service "/angle_vector_finished" std_srvs::Empty #'angle-vector-finished-cb)
+    (setq *wait-interpolation-from-ocs-inited* t))
+  (setq *angle-vector-finished* nil)
+  (while (not *angle-vector-finished*) 
+    (ros::sleep)
+    (ros::spin-once))
+  )
+
+(defun angle-vector-finished-cb
+  (req)
+  (setq *angle-vector-finished* t)
+  (send req :response))
+
+(defun send-angle-vector-finished-service
+  ()
+  (ros::service-call "/angle_vector_finished" (instance std_srvs::EmptyRequest :init))
   )
 
 ;; get potentio-vector from ocs


### PR DESCRIPTION
[メモ]
RvizのGUIから関節角を送るときに，wait-interpolationできるようにする．
このPRは send-angle-vector-from-ocs をせずに，wait-interpolation-from-ocs をすると，返ってこなくなる仕様．
なおすには，OCS側でangle-vectorを送る状態を追加して，その状態を監視すればよい．