### PR TITLE
[drc_task_common] use :active-state method instead of slot 'active-state'

### DIFF
--- a/jsk_2015_06_hrp_drc/drc_task_common/euslisp/state-machine.l
+++ b/jsk_2015_06_hrp_drc/drc_task_common/euslisp/state-machine.l
@@ -42,7 +42,7 @@
   (:next? (next-state)
     "return t if state machine can go to next-state from the current state"
     (or (eq (send self :state) next-state)
-        (let ((candidate-transitions (send self :lookup-transitions active-state)))
+        (let ((candidate-transitions (send self :lookup-transitions (send self :active-state))))
           (not (null (remove-if-not #'(lambda (trans)
                                         (eq next-state
                                             (send (send trans :to) :name)))


### PR DESCRIPTION
use :active-state method instead of slot 'active-state' directly in `state-machine.l`