### PR TITLE
[drc_task_common] Add script to convert ar_pose/ARMarker to geometry_msgs/PoseStamped

### DIFF
--- a/jsk_2015_06_hrp_drc/drc_task_common/package.xml
+++ b/jsk_2015_06_hrp_drc/drc_task_common/package.xml
@@ -51,6 +51,8 @@
   <build_depend>jsk_rqt_plugins</build_depend>
   <build_depend>jsk_rviz_plugins</build_depend>
   <build_depend>smach_msgs</build_depend>
+  <build_depend>ar_pose</build_depend>
+  
   <run_depend>rosbuild</run_depend>
   <run_depend>mk</run_depend>
   <run_depend>roseus</run_depend>
@@ -94,6 +96,7 @@
   <run_depend>jsk_rviz_plugins</run_depend>
   <run_depend>smach_msgs</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
+  <run_depend>ar_pose</run_depend>
   <export>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
     <rviz plugin="${prefix}/plugin_description.xml"/>  


### PR DESCRIPTION
Be careful: You need to install ar_tools into your ros workspace by
```
$ wstool set --git ar_tools https://github.com/ar-tools/ar_tools.git
```