### PR TITLE
remap locomotion_planner

### DIFF
--- a/jsk_2015_06_hrp_drc/drc_task_common/launch/ocs/ocs_locomotion_planner.launch
+++ b/jsk_2015_06_hrp_drc/drc_task_common/launch/ocs/ocs_locomotion_planner.launch
@@ -3,7 +3,7 @@
   <remap from="/tf" to="/ocs/tf" />
   <remap from="/joint_states" to="/ocs/joint_states" />
   <remap from="/robot_description" to="/ocs/robot_description" />
-  <group>
+  <group ns="ocs">
     <!-- Footstep planner -->
     <node pkg="jsk_footstep_planner"
           type="footstep-planner-node.l"


### PR DESCRIPTION
これで #998 のeusが突然死する，が直るかもしれません
eusの突然死はros::spin-onceのところで起こっていて，
footstep_plannerのclientを作るところをコメントアウトして数回試したら突然死が起きなくなったので．
変更したあたりが動かなくなるかもしれないので @garaemon さん確認お願いします．