### PR TITLE
exec in simulation mode

### DIFF
--- a/jsk_2013_04_pr2_610/euslisp/move-chair.l
+++ b/jsk_2013_04_pr2_610/euslisp/move-chair.l
@@ -28,7 +28,7 @@
 ;;if you call this function, (as like (start-detect-chair))
 ;;*chair* will be update and move to where it would be
 (defun start-detect-chair (&key (debug nil))
-  (unless (send *ri* :joint-action-enable)
+  (unless (send *ri* :simulation-modep)
     (return-from start-detect-chair nil)
     )
   (let ((loop t) (loop-counter 0) (chair-coords nil) (ret))
@@ -150,7 +150,7 @@
       (send *ri* :wait-interpolation)
 
 
-      (if (not (send *ri* :joint-action-enable))
+      (if (not (send *ri* :simulation-modep))
 	  ;; if simulation
 	  (progn
 	    (setq grasp-success t)

--- a/jsk_2013_04_pr2_610/euslisp/pick-broom.l
+++ b/jsk_2013_04_pr2_610/euslisp/pick-broom.l
@@ -94,7 +94,7 @@
     (send *ri* :wait-interpolation)
 
     (send *ri* :start-grasp :larm)
-    (when (and (send *ri* :joint-action-enable) (< (send *ri* :start-grasp :larm) 3.0))
+    (when (and (send *ri* :simulation-modep) (< (send *ri* :start-grasp :larm) 3.0))
       (send *ri* :stop-grasp :larm :wait t)
       (speak-jp "ほうきとれなかった")
       (send *ri* :angle-vector av0 3000)

--- a/jsk_2013_04_pr2_610/euslisp/pick-cloth.l
+++ b/jsk_2013_04_pr2_610/euslisp/pick-cloth.l
@@ -157,7 +157,7 @@
       (send *ri* :start-grasp :larm :objects nil) ;; wait motion and grasp
       (setq grasp-width (send *ri* :start-grasp :larm :objects nil)) ;; wait motion and grasp ;; make sure that we really grasp cloth
       ;; if pr2 fail to grasp the cloth, return nil.
-      (when (and (send *ri* :joint-action-enable) (< grasp-width 1.1))
+      (when (and (send *ri* :simulation-modep) (< grasp-width 1.1))
 	(send *ri* :go-pos-unsafe -0.2 0 0)
 	(send *pr2* :translate #f(-200 0 0))
 	(return-from pick-cloth-chair nil)

--- a/jsk_2013_04_pr2_610/euslisp/pick-tray.l
+++ b/jsk_2013_04_pr2_610/euslisp/pick-tray.l
@@ -16,7 +16,7 @@
     (send *ri* :wait-interpolation)
     
     ;;detect tray when real robot
-    (if (send *ri* :joint-action-enable)
+    (if (send *ri* :simulation-modep)
 	(tray-detection *tray*)
       )
     (setq tray-larm-handle (send (send (send *tray* :handle-larm-handle) :copy-worldcoords) :rotate (deg2rad -20) :z) ;; do not move in world coords, use object(tray) relative coords
@@ -52,7 +52,7 @@
     (setq grasp-args (send *ri* :start-grasp :arms :objects (list (find *tray* (send *ri* :objects) :test #'(lambda (a b) (string= (send a :name) (send b :name)))))))  ;; stop-grasp wait until gripper motion stops
 	;; check if tray is grasped
     (warning-message 3 "check tray ~A > ~A~%" grasp-args grasp-threshold)
-    (when (and (send *ri* :joint-action-enable)
+    (when (and (send *ri* :simulation-modep)
 	       (or (< (elt grasp-args 0) (elt grasp-threshold 0))
 		   (< (elt grasp-args 1) (elt grasp-threshold 1))))
       (warning-message 3 "tray is not grasped~%")

--- a/jsk_2013_04_pr2_610/euslisp/put-cloth-into-laundry.l
+++ b/jsk_2013_04_pr2_610/euslisp/put-cloth-into-laundry.l
@@ -118,7 +118,7 @@
     (send *ri* :wait-interpolation)
 
     ;; change laundry button pos according to image processing
-    (if (send *ri* :joint-action-enable)
+    (if (send *ri* :simulation-modep)
 	(send *laundry* :move-to (laundry-detection *laundry*) :world);; FIX ME returns t if found, nil not found
     )
     (if (boundp '*irtviewer*) (send (send *laundry* :copy-worldcoords)

--- a/jsk_demo_common/euslisp/pr2-action.l
+++ b/jsk_demo_common/euslisp/pr2-action.l
@@ -376,8 +376,9 @@
               :rotation-axis t :sec start-sec :move-robot move-robot)
 
     (let ((grasp-ret (if move-robot (send *ri* :start-grasp hand :gain 0.1) 10)))
-      (when (and grasp-check
-                 (< grasp-ret 8)) ;; grasp
+      (when (and (send *ri* :joint-action-enable) ;;return only in real mode
+                 (and grasp-check
+                      (< grasp-ret 8))) ;; grasp
         (ros::ros-warn "Grasp handle failed, return from execute-open")
         (return-from move-fridge-traj nil)))
 
@@ -600,6 +601,7 @@
      ))
   )
 
+(defparameter *fridge-handle-cds* nil)
 (defun move-to-and-open-fridge-door (&key (door-type :circle) (ratio 1) (look-around nil) (head-pitch 14) (torso-lift 130) (move t) (open-fridge-func #'open-fridge-traj))
   (let (ret
         (idealcds
@@ -618,9 +620,15 @@
         cds
         )
     ;; finding handle position
-    (setq cds (check-detection :type "fridge" :speak-name *frige-speak-str*
-                               :detection-topic "/openni/rgb/ObjectDetection"
-                               ))
+    (cond
+     ((send *ri* :joint-action-enable) ;; real mode
+      (setq cds (check-detection :type "fridge" :speak-name *frige-speak-str*
+                                 :detection-topic "/openni/rgb/ObjectDetection"
+                                 )))
+     (t ;; simulation mode
+      (setq cds (send (make-cube 60 60 60) :translate (float-vector 777 98 1112)))
+      ))
+    (setq *fridge-handle-cds* cds)
     ;; need detection fail check
     (send *ri* :ros-wait 0.0 :spin-self t) ;; attention-check ...
     (when cds
@@ -642,13 +650,19 @@
       (warn "~%~A -> ~A / ~A~%" diffcds cds idealcds)
       (ros::ros-info "DIFF: ~A" diffcds)
       (cond
-       ((and (< (norm (float-vector (elt (send diffcds :worldpos) 0)
-                                    (elt (send diffcds :worldpos) 1)))
-                *fridge-distance-threshold*)
-             (< (abs (elt (car (rpy-angle (send diffcds :worldrot))) 0))
-                *fridge-rotation-threshold*))
-        (setq cds (check-detection :type "fridge" :speak-name *frige-speak-str*
-                                   :detection-topic "/openni/rgb/ObjectDetection"))
+       ((or (not (send *ri* :joint-action-enable)) ;;if in simulation mode, execute
+            (and (< (norm (float-vector (elt (send diffcds :worldpos) 0)
+                                        (elt (send diffcds :worldpos) 1)))
+                    *fridge-distance-threshold*)
+                 (< (abs (elt (car (rpy-angle (send diffcds :worldrot))) 0))
+                    *fridge-rotation-threshold*)))
+        (cond
+         ((send *ri* :joint-action-enable) ;; real mode
+          (setq cds (check-detection :type "fridge" :speak-name *frige-speak-str*
+                                     :detection-topic "/openni/rgb/ObjectDetection"))
+          )
+         (t ;; simulation mode
+          (setq cds (send (make-cube 60 60 60) :translate (float-vector 777 98 1112)))))
         (send *ri* :ros-wait 0.0 :spin-self t :spin t) ;; attention-check ...
         ;; (y-or-n-p "Can I start open fridge? ")
         (when cds
@@ -867,17 +881,23 @@
   (send *ri* :angle-vector (send *pr2* :angle-vector) 2000)
   )
 
+(defparameter *can-cds* nil)
 (defun grasp-can-motion (&key (use-arm :rarm) (rotation 20))
   ;; detect cans which was indicated by ( type )
   ;;(when (not (setq cds (check-detection :type *type* :single t)))
   ;;(setq cds (check-detection :type *type* :tf-force t :timeout 30 :single t)))
   (let (cds isgrasp)
-    (unless (setq cds (check-detection :speak-name *type*
-                                       :type *type* :tf-force t :timeout 35 :single t
-                                       :detection-topic "/openni_c2/depth_registered/ObjectDetection"))
-      (setq cds (check-detection :speak-name *type*
-                                 :type *type* :tf-force t :timeout 70 :single t
-                                 :detection-topic "/openni_c2/depth_registered/ObjectDetection")))
+    (cond
+     ((send *ri* :joint-action-enable) ;; real mode
+      (unless (setq cds (check-detection :speak-name *type*
+                                         :type *type* :tf-force t :timeout 35 :single t
+                                         :detection-topic "/openni_c2/depth_registered/ObjectDetection"))
+        (setq cds (check-detection :speak-name *type*
+                                   :type *type* :tf-force t :timeout 70 :single t
+                                   :detection-topic "/openni_c2/depth_registered/ObjectDetection"))))
+     (t ;; simulation mode
+      (setq cds (send (make-cube 60 60 60) :translate (float-vector 756 302 1164)))))
+    (setq *can-cds* cds)
     (send *ri* :ros-wait 0.0 :spin-self t :spin t) ;; attention-check ...
     (when cds
       ;; (speak-jp (format nil "~A を とりだします" *type*))
@@ -897,6 +917,9 @@
       (setq *last-can-coords* cds)
       (grasp-can-single cds :rotation rotation :use-arm use-arm)
       (setq isgrasp (< 10 (send *ri* :start-grasp use-arm)))
+      (if (not (send *ri* :joint-action-enable)) ;; in simulation mode, set isgrasp true
+          (setq isgrasp t))
+      (ros::ros-info "isgrasp : ~A" isgrasp)
       (when isgrasp
         (return-from grasp-can-motion t))
       ;; (unix::sleep 2)

--- a/jsk_demo_common/euslisp/pr2-action.l
+++ b/jsk_demo_common/euslisp/pr2-action.l
@@ -185,7 +185,7 @@
 (warn ";; define detect-with-base-laser")
 (defun detect-with-base-laser (obj obj-type &key (arg nil) (debug nil) (speak nil) (publish-marker nil))
   (ros::ros-info "detect-with-base-laser~%")
-  (unless (send *ri* :joint-action-enable)
+  (unless (send *ri* :simulation-modep)
 	(if obj (ros::ros-warn "~A detection failed" obj))
     (return-from detect-with-base-laser nil)
     )
@@ -376,7 +376,7 @@
               :rotation-axis t :sec start-sec :move-robot move-robot)
 
     (let ((grasp-ret (if move-robot (send *ri* :start-grasp hand :gain 0.1) 10)))
-      (when (and (send *ri* :joint-action-enable) ;;return only in real mode
+      (when (and (send *ri* :simulation-modep) ;;return only in real mode
                  (and grasp-check
                       (< grasp-ret 8))) ;; grasp
         (ros::ros-warn "Grasp handle failed, return from execute-open")
@@ -621,7 +621,7 @@
         )
     ;; finding handle position
     (cond
-     ((send *ri* :joint-action-enable) ;; real mode
+     ((send *ri* :simulation-modep) ;; real mode
       (setq cds (check-detection :type "fridge" :speak-name *frige-speak-str*
                                  :detection-topic "/openni/rgb/ObjectDetection"
                                  )))
@@ -650,14 +650,14 @@
       (warn "~%~A -> ~A / ~A~%" diffcds cds idealcds)
       (ros::ros-info "DIFF: ~A" diffcds)
       (cond
-       ((or (not (send *ri* :joint-action-enable)) ;;if in simulation mode, execute
+       ((or (not (send *ri* :simulation-modep)) ;;if in simulation mode, execute
             (and (< (norm (float-vector (elt (send diffcds :worldpos) 0)
                                         (elt (send diffcds :worldpos) 1)))
                     *fridge-distance-threshold*)
                  (< (abs (elt (car (rpy-angle (send diffcds :worldrot))) 0))
                     *fridge-rotation-threshold*)))
         (cond
-         ((send *ri* :joint-action-enable) ;; real mode
+         ((send *ri* :simulation-modep) ;; real mode
           (setq cds (check-detection :type "fridge" :speak-name *frige-speak-str*
                                      :detection-topic "/openni/rgb/ObjectDetection"))
           )
@@ -888,7 +888,7 @@
   ;;(setq cds (check-detection :type *type* :tf-force t :timeout 30 :single t)))
   (let (cds isgrasp)
     (cond
-     ((send *ri* :joint-action-enable) ;; real mode
+     ((send *ri* :simulation-modep) ;; real mode
       (unless (setq cds (check-detection :speak-name *type*
                                          :type *type* :tf-force t :timeout 35 :single t
                                          :detection-topic "/openni_c2/depth_registered/ObjectDetection"))
@@ -917,7 +917,7 @@
       (setq *last-can-coords* cds)
       (grasp-can-single cds :rotation rotation :use-arm use-arm)
       (setq isgrasp (< 10 (send *ri* :start-grasp use-arm)))
-      (if (not (send *ri* :joint-action-enable)) ;; in simulation mode, set isgrasp true
+      (if (not (send *ri* :simulation-modep)) ;; in simulation mode, set isgrasp true
           (setq isgrasp t))
       (ros::ros-info "isgrasp : ~A" isgrasp)
       (when isgrasp
@@ -1234,7 +1234,7 @@
       (send *ri* :wait-interpolation))
 
     ;;detect tray when real robot
-    (when (send *ri* :joint-action-enable)
+    (when (send *ri* :simulation-modep)
 
       (let ((cnt 0))
         (while (and (<= cnt 3) (not (tray-detection target)))
@@ -1332,7 +1332,7 @@
 
     ;; check if tray is grasped
     (warning-message 3 "check tray ~A > ~A~%" grasp-args grasp-threshold)
-    (when (and (send *ri* :joint-action-enable)
+    (when (and (send *ri* :simulation-modep)
                (or (< (elt grasp-args 0) (elt grasp-threshold 0))
                    (< (elt grasp-args 1) (elt grasp-threshold 1))))
       (warning-message 3 "tray is not grasped~%")


### PR DESCRIPTION
##### Now fridge demo is executable in simulation mode (irtviewer)
Instead of recognizing the positions of fridge handle or can, the positions are given.
So, the behavior of PR2 is shortly different.

(For example, think about PR2 approach to the fridge handle.
In real, PR2 approach to the fridge several times because the distance between PR2 and fridge handle is not in the given thereshold.
But, in irtviewer, PR2 approach to the fridge only one time because I just give the handle position and PR2 just grasp that position.)

It might be better to be able to execute demo in kinematics mode too.
(Because in kinematics mode, go-pos is simulated, and these situations can be simulated. )