### PR TITLE
[jsk_demo_common/euslisp/pr2-action.l] fix: add '_lk' to link name

### DIFF
--- a/jsk_demo_common/euslisp/pr2-action.l
+++ b/jsk_demo_common/euslisp/pr2-action.l
@@ -39,7 +39,7 @@
 		  :move-target (send *pr2* arm :end-coords)
 		  :link-list (send *pr2* :link-list
 						   (send *pr2* arm :end-coords :parent)
-						   (send *pr2* :torso_lift_link))
+						   (send *pr2* :link "torso_lift_link"))
 		  :debug-view nil)
     (send *ri* :angle-vector (send *pr2* :angle-vector) 2000)
     (send *ri* :wait-interpolation)
@@ -120,7 +120,7 @@
 	  :move-target (send *pr2* arm :end-coords)
 	  :link-list (send *pr2* :link-list
 			   (send *pr2* arm :end-coords :parent)
-			   (send *pr2* :torso_lift_link))
+			   (send *pr2* :link "torso_lift_link"))
 	  :debug-view debug)
     (send *ri* :angle-vector (send *pr2* :angle-vector) 2000)
     (send *ri* :wait-interpolation)


### PR DESCRIPTION
fix for change of calling link name directly in pr2-interface