### PR TITLE
gazebo_drive_simulator does not have python modules

### DIFF
--- a/jsk_2015_06_hrp_drc/gazebo_drive_simulator/CMakeLists.txt
+++ b/jsk_2015_06_hrp_drc/gazebo_drive_simulator/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(catkin REQUIRED COMPONENTS
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
 ## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-catkin_python_setup()
+#catkin_python_setup()
 
 ################################################
 ## Declare ROS messages, services and actions ##


### PR DESCRIPTION
this blocks https://travis-ci.org/jsk-ros-pkg/jsk_smart_apps/jobs/74776198 (https://github.com/jsk-ros-pkg/jsk_smart_apps/pull/56) with
```
]2;[build] 3/21[[36mgazebo_drive_simulator[0m] +/usr/bin/env PYTHONPATH=/home/travis/ros/ws_jsk_smart_apps/install/lib/python2.7/dist-packages:/home/travis/ros/ws_jsk_smart_apps/build/gazebo_drive_simulator/lib/python2.7/dist-packages:/opt/ros/hydro/lib/python2.7/dist-packages CATKIN_BINARY_DIR=/home/travis/ros/ws_jsk_smart_apps/build/gazebo_drive_simulator /usr/bin/python /home/travis/ros/ws_jsk_smart_apps/src/jsk-ros-pkg/jsk_demos/jsk_2015_06_hrp_drc/gazebo_drive_simulator/setup.py build --build-base /home/travis/ros/ws_jsk_smart_apps/build/gazebo_drive_simulator install --install-layout=deb --prefix=/home/travis/ros/ws_jsk_smart_apps/install --install-scripts=/home/travis/ros/ws_jsk_smart_apps/install/bin[0m [0m[0m
]2;[build] 3/21[[36mgazebo_drive_simulator[0m] running build[0m                                          [0m[0m
]2;[build] 3/21[[36mgazebo_drive_simulator[0m] running build_py[0m                                       [0m[0m
]2;[build] 3/21[[36mgazebo_drive_simulator[0m] error: package directory 'src/gazebo_drive_simulator' does not exist[0m [0m[0m
]2;[build] 3/21[[36mgazebo_drive_simulator[0m] CMake Error at catkin_generated/safe_execute_install.cmake:4 (message):[0m [0m[0m
]2;[build] 3/21[[36mgazebo_drive_simulator[0m] [0m                                                       [0m[0m
]2;[build] 3/21[[36mgazebo_drive_simulator[0m]   execute_process(/home/travis/ros/ws_jsk_smart_apps/build/gazebo_drive_simulator/catkin_generated/python_distutils_install.sh)[0m [0m[0m
]2;[build] 3/21[[36mgazebo_drive_simulator[0m]   returned error code[0m                                  [0m[0m
]2;[build] 3/21[[36mgazebo_drive_simulator[0m] Call Stack (most recent call first):[0m                   [0m[0m
]2;[build] 3/21[[36mgazebo_drive_simulator[0m]   cmake_install.cmake:90 (INCLUDE)[0m                     [0m[0m
]2;[build] 3/21[[36mgazebo_drive_simulator[0m] [0m                                                       [0m[0m
]2;[build] 3/21[[36mgazebo_drive_simulator[0m] [0m                                                       [0m[0m
]2;[build] 3/21[[36mgazebo_drive_simulator[0m] make: *** [install] Error 1[0m                            [0m[0m
]2;[build] 3/21[[36mgazebo_drive_simulator[0m] [1m[31m<==[0m '[1m/home/travis/ros/ws_jsk_smart_apps/build/gazebo_drive_simulator/build_env.sh /usr/bin/make install[0m' [31mfailed with return code[0m '[1m2[0m'[0m [0m[0m
]2;[build] 3/21[1m[31mFailed[0m   [32m<==[0m [36mgazebo_drive_simulator      [0m [ [33m21.1 seconds[0m ][0m                      [0m[0m
[build] Calculating new jobs...                                                 [0m[0m

```

@Terasawa
@orikuma