### PR TITLE
[detect_cans] async join based parallel state-machine

### DIFF
--- a/detect_cans_in_fridge_201202/euslisp/async-join-based-parallel-smach-main.l
+++ b/detect_cans_in_fridge_201202/euslisp/async-join-based-parallel-smach-main.l
@@ -1,0 +1,501 @@
+
+
+(ros::load-ros-manifest "roseus_smach")
+(ros::roseus "async_join_state_machine_based_fridge_demo")
+
+(require :state-machine-actionlib "package://roseus_smach/src/state-machine-actionlib.l")
+
+(defmethod async-join-state
+  (:execute
+   (userdata &key (step nil))
+   (let (start-time ret clients part-async-client-lst)
+     (send self :remap userdata :invert nil)
+     (setq start-time (ros::time-now))
+     (setq part-async-client-lst (cdr (assoc :part-async userdata)))
+     (cond
+      ((null part-async-client-lst) ; normal mode
+       (setq clients (cdr (assoc :async userdata)))
+       (when (atom clients)
+         (setq clients (list clients)))
+       (warning-message 2 "<normal async join> waiting action client: ~A~%" clients)
+       (send-all clients :spin-once)
+       (if (member nil (send-all clients :wait-for-result :timeout timeout))
+           (setq ret nil) (setq ret t))
+       (warn "ret: ~A~%" ret)
+       (set-alist :results (send-all clients :get-result) userdata)
+       (warn "result: ~A~%" (send-all clients :get-result))
+       )
+      (t ; partly join
+       (warning-message 2 "<part async join> waiting action client:~A" part-async-client-lst)
+       (send-all part-async-client-lst :spin-once)
+       (if (member nil (send-all part-async-client-lst :wait-for-result :timeout timeout))
+           (setq ret nil) (setq ret t))
+       (warn "ret: ~A~%" ret)
+       (set-alist :results (send-all part-async-client-lst :get-result) userdata)
+       (warn "result: ~A~%" (send-all part-async-client-lst :get-result))
+       ))
+     (send self :remap userdata :invert t)
+     (return-from :execute ret))))
+
+(defun actionlib-client-state
+  (name client my-controller-lst
+        &key (timeout 10) (retry nil) (key #'identity) (return-success :succeeded) (return-fail :failed)
+        (async nil) (return-async t))
+  (send client :wait-for-server)
+  (instance state :init name
+            ;; main loop
+            `(lambda (userdata)
+               (let ((start (ros::time-now)) async-clients)
+                 (send ,client :send-goal
+                       (funcall (quote ,key) (cdr (assoc :goal userdata))))
+                 (if ,async
+                     (progn
+                       (setq async-clients (cdr (assoc :async userdata)))
+                       (set-alist :async (flatten (list async-clients ,client)) userdata)
+                       ;; add client to controller-lst in userdata
+                       (if (not (null ',my-controller-lst))
+                           (progn
+                             (dolist (controller ',my-controller-lst)
+                               (let (client-lst)
+                                 (setq client-lst (cdr (assoc controller userdata)))
+                                 (set-alist controller (flatten (list client-lst ,client)) userdata)
+                                 ))))
+
+                       (ros::sleep)
+                       (send ,client :spin-once)
+                       ,return-async)
+                   (while (ros::ok)
+                     (ros::sleep)
+                     (send ,client :spin-once)
+                     ;;
+                     (cond
+                      ((eq (send ,client :get-state) actionlib_msgs::GoalStatus::*SUCCEEDED*)
+                       (return ,return-success))
+                      ((eq (send ,client :get-state) actionlib_msgs::GoalStatus::*ABORTED*)
+                       (if ,retry
+                           (send ,client :send-goal
+                                 (funcall (quote ,key) (cdr (assoc :goal userdata))))
+                         (return ,return-fail)))
+                      ((member (send ,client :get-state)
+                               (list actionlib_msgs::GoalStatus::*PREEMPTED*
+                                     actionlib_msgs::GoalStatus::*RECALLED*
+                                     actionlib_msgs::GoalStatus::*REJECTED*))
+                       (return ,return-fail))
+                      ((member (send ,client :get-state)
+                               (list actionlib_msgs::GoalStatus::*ACTIVE*
+                                     actionlib_msgs::GoalStatus::*PENDING*))
+                       ;; user cancel
+                       (if (and (vectorp (cdr (assoc :cancel userdata)))
+                                (elt (cdr (assoc :cancel userdata)) 0))
+                           (send ,client :cancel-goal))
+                       ;; time out
+                       (if (and (numberp ,timeout)
+                                (< ,timeout (send (ros::time- (ros::time-now) start) :to-sec)))
+                           (send ,client :cancel-goal))))
+                     )))))
+  )
+
+(defun smach-exec (sm)
+  (let ((insp (instance state-machine-inspector :init sm))
+        (mydata (list (cons 'count 0) (cons 'hoge (list 1 2 3)))))
+    (unix:sleep 1) ;; for advertize topics successfully
+    (send sm :reset-state)
+    (send insp :publish-structure)
+    (send insp :publish-status mydata)
+    (while (not (send sm :goal-reached))
+      ;; (unix:sleep 1)
+      (ros::spin-once)
+      (send insp :publish-status mydata)
+      ;; you can execute state-machine step by step
+      (send sm :execute mydata :step -1))
+    (send sm :active-state) ;; return reached goal state
+    ))
+
+(defun smach-exec-in-stages (sm)
+  (let ((insp (instance state-machine-inspector :init sm))
+        (mydata (list (cons 'count 0) (cons 'hoge (list 1 2 3)))))
+    (unix:sleep 1) ;; for advertize topics successfully
+    (send sm :reset-state)
+    (send insp :publish-structure)
+    (send insp :publish-status mydata)
+    (while (not (send sm :goal-reached))
+      ;; (unix:sleep 1)
+      (warn "Enter:")
+      (read-line)
+      (ros::spin-once)
+      (send insp :publish-status mydata)
+      ;; you can execute state-machine step by step
+      (send sm :execute mydata :step -1))
+    (send sm :active-state) ;; return reached goal state
+    ))
+
+(defun start (&optional userdata)
+  (ros::ros-info "    Info: start function is being executed.")
+  ;; (send *ri* :angle-vector (send *pr2* :reset-pose))
+  :success
+  )
+
+(defun convert (val)
+  (let ((goal (instance roseus_smach::Sub5ActionGoal :init)))
+    (send goal :goal :value val)
+    goal))
+
+(defun update-client-lst (userdata)
+  (let ((async-client-lst (cdr (assoc :async userdata)))
+        (part-async-client-lst (cdr (assoc :part-sync userdata)))
+        (base-client-lst (cdr (assoc :base userdata)))
+        (head-client-lst (cdr (assoc :head userdata)))
+        (rarm-client-lst (cdr (assoc :rarm userdata)))
+        (larm-client-lst (cdr (assoc :larm userdata)))
+        (rgripper-client-lst (cdr (assoc :rgripper userdata)))
+        (lgripper-client-lst (cdr (assoc :lgripper userdata)))
+        (torso-client-lst (cdr (assoc :torso userdata)))
+        )
+    (dolist (client async-client-lst)
+      (send client :spin-once)
+      (ros::ros-info "client: ~A   goal state: ~A" client (send client :get-state))
+      (cond
+       ((equal (send client :get-state) actionlib_msgs::GoalStatus::*succeeded*)
+        (ros::ros-info "Delete the client(~A)." client)
+        ;; delete the client from all lists
+        (setq async-client-lst (remove client async-client-lst)
+              part-async-client-lst (remove client part-async-client-lst)
+              base-client-lst (remove client base-client-lst)
+              head-client-lst (remove client head-client-lst)
+              rarm-client-lst (remove client rarm-client-lst)
+              larm-client-lst (remove client larm-client-lst)
+              rgripper-client-lst (remove client rgripper-client-lst)
+              lgripper-client-lst (remove client lgripper-client-lst)
+              torso-client-lst (remove client torso-client-lst)
+              ))
+       (t
+        ;; nothing
+        )
+       ))
+    ;; set those to userdata
+    (set-alist :async async-client-lst userdata)
+    (set-alist :part-async part-async-client-lst userdata)
+    (set-alist :base base-client-lst userdata)
+    (set-alist :head head-client-lst userdata)
+    (set-alist :rarm rarm-client-lst userdata)
+    (set-alist :larm larm-client-lst userdata)
+    (set-alist :rgripper rgripper-client-lst userdata)
+    (set-alist :lgripper lgripper-client-lst userdata)
+    (set-alist :torso torso-client-lst userdata)
+    (ros::ros-info "updated userdata: ~A" userdata)
+    ))
+
+(defun set-part-async-client-lst (userdata my-controller-lst)
+  (let ((part-async-client-lst (cdr (assoc :part-async userdata)))
+        hazard-assoc-lst
+        )
+    (setq hazard-assoc-lst
+          '((:base :rgripper :lgripper)
+            (:head)
+            (:rarm :rgripper :base)
+            (:larm :lgripper :base)
+            (:rgripper :rarm :base :torso)
+            (:lgripper :larm :base :torso)
+            (:torso :rgripper :lgripper)
+            ))
+    (dolist (controller my-controller-lst)
+      (dolist (ctr (assoc controller hazard-assoc-lst))
+        (let ((client-lst (cdr (assoc ctr userdata))))
+          (cond
+           ((null (car client-lst))
+            ;;no clients
+            )
+           (t
+            (setq part-async-client-lst (append part-async-client-lst client-lst))
+            )))))
+    (setq part-async-client-lst (remove-duplicates part-async-client-lst))
+    (set-alist :part-async part-async-client-lst userdata)
+    ))
+
+(defmacro make-check-function (user-defined-function my-controller-lst)
+  `(let ()
+     (cond
+      ((not (functionp ',user-defined-function))
+       '(lambda (userdata)
+          ;; update
+          (update-client-lst userdata)
+          (ros::ros-info "    user function not defined. Check structure hazard.")
+          (cond
+           ((equal (car (cdr (assoc :async userdata))) nil)
+            t)
+           (t
+            (cond
+             ((null ',my-controller-lst)
+              (warning-message 2 "my-controller-lst not defined. Wait all clients.~%")
+              (set-alist :part-async nil userdata)
+              nil
+              )
+             (t
+              ;; There are some clients waiting result.
+              (set-part-async-client-lst userdata ',my-controller-lst)
+              (let ((part-async-client-lst (cdr (assoc :part-async userdata)))
+                    )
+                (cond
+                 ((null part-async-client-lst)
+                  t)
+                 (t
+                  nil))
+                )))))))
+      (t
+       '(lambda (userdata)
+          ;; update
+          (update-client-lst userdata)
+          (ros::ros-info "    user function found. Exec user function.")
+          (,user-defined-function userdata)
+          t
+          )))
+     ))
+
+(defun make-hazard-remap-lst (&optional my-controller-lst (all nil))
+  (let ((remap-lst '((:async . async-clients)
+                     (:part-async . part-async-clients))))
+    (when all
+      (setq my-controller-lst '(:base :head :rarm :larm :rgripper :lgripper :torso)))
+    (dolist (controller my-controller-lst)
+      (case controller
+        ((:base)
+         (setq remap-lst (append remap-lst '((:base . base-clients)))))
+        ((:head)
+         (setq remap-lst (append remap-lst '((:head . head-clients)))))
+        ((:rarm)
+         (setq remap-lst (append remap-lst '((:rarm . rarm-clients)))))
+        ((:larm)
+         (setq remap-lst (append remap-lst '((:larm . larm-clients)))))
+        ((:rgripper)
+         (setq remap-lst (append remap-lst '((:rgripper . rgripper-clients)))))
+        ((:lgripper)
+         (setq remap-lst (append remap-lst '((:lgripper . lgripper-clients)))))
+        ((:torso)
+         (setq remap-lst (append remap-lst '((:torso . torso-clients)))))
+        ))
+    remap-lst
+    ))
+
+(defmacro make-async-join-based-structure-hazard-check-state-machine
+  (sm-name &optional (my-controller-lst nil) (check-func nil))
+  "make hazard-check-state-machine"
+  `(let (st-check st-join st-exec ac-name)
+     (cond
+      ((boundp ',sm-name)
+       (ros::ros-warn "state-machine(~A) is already created. Use different name." ',sm-name)
+       ,sm-name
+       )
+      (t
+       (setq st-check (intern (string-upcase (format nil "~A-check" ',sm-name)) *keyword-package*))
+       (setq st-join (intern (string-upcase (format nil "~A-join" ',sm-name)) *keyword-package*))
+       (setq st-exec (intern (string-upcase (format nil "~A-exec" ',sm-name)) *keyword-package*))
+       (setq ac-name  (string-downcase (substitute  #\_ #\- (format nil "~A" ',sm-name))))
+       (setq ,sm-name (instance state-machine :init))
+       (setq client (instance ros::simple-action-client :init
+                              ac-name roseus_smach::Sub5Action))
+       (send ,sm-name :add-node
+             (instance state :init st-check
+                       (make-check-function ,check-func ,my-controller-lst)))
+       (send (send ,sm-name :node st-check) :remap-list (make-hazard-remap-lst nil t))
+       (send ,sm-name :add-node (instance async-join-state :init st-join :timeout 50
+                                          :remap-list (make-hazard-remap-lst)))
+       (send ,sm-name :add-node (actionlib-client-state st-exec client ',my-controller-lst :async t :timeout 40 :retry t :key 'convert))
+       (send (send ,sm-name :node st-exec) :remap-list (make-hazard-remap-lst ',my-controller-lst))
+       (send ,sm-name :goal-state (list :success :failure))
+       (send ,sm-name :add-transition st-check st-exec t)
+       (send ,sm-name :add-transition st-check st-join nil)
+       (send ,sm-name :add-transition st-join st-exec t)
+       (send ,sm-name :add-transition st-exec :success t)
+       (send ,sm-name :add-transition st-exec :failure nil)
+       (send ,sm-name :start-state st-check)
+       (send ,sm-name :arg-keys
+             'async-clients 'part-async-clients 'base-clients
+             'head-clients 'rarm-clients 'larm-clients
+             'rgripper-clients 'lgripper-clients 'torso-clients)
+       ,sm-name
+       ))))
+
+(defmacro make-hsm (state-machine-name state-machine-information-lst)
+  (let ((prev-sm (gensym))
+        (next-sm (gensym))
+        )
+    `(let (state-machine-lst)
+       (cond
+        ((boundp ',state-machine-name)
+         (ros::ros-warn "state-machine(~A) is already created. Use different name." ',state-machine-name)
+         ,state-machine-name)
+        (t
+         (setq ,state-machine-name (instance state-machine :init))
+         (send ,state-machine-name :add-node (instance state :init :start 'start))
+         (dolist (sm-info ,state-machine-information-lst)
+           (cond
+            ((and (not (listp sm-info))
+                  (derivedp (eval sm-info) state-machine))
+             (ros::ros-info "Detected state-machine(~A)." sm-info)
+             (send ,state-machine-name :add-node
+                   (instance state :init
+                             (intern (string sm-info) *keyword-package*) (eval sm-info)))
+             (setq state-machine-lst (append state-machine-lst (list (intern (string sm-info) *keyword-package*))))
+             )
+            (t
+             (send ,state-machine-name :add-node
+                   (instance state :init (intern (string (car sm-info)) *keyword-package*)
+                             (eval `(make-async-join-based-structure-hazard-check-state-machine
+                                     ,(car sm-info) ,(cadr sm-info) ,(caddr sm-info)))))
+             (setq state-machine-lst (append state-machine-lst (list (intern (string (car sm-info)) *keyword-package*))))
+             )))
+         (send ,state-machine-name :arg-keys
+               'async-clients 'part-async-clients 'base-clients
+               'head-clients 'rarm-clients 'larm-clients
+               'rgripper-clients 'lgripper-clients 'torso-clients)
+         (send ,state-machine-name :start-state :start)
+         (send ,state-machine-name :goal-state (list :success))
+         (setq prev-sm :start)
+         (dolist (st-mn state-machine-lst)
+           (setq next-sm st-mn)
+           (send ,state-machine-name :add-transition prev-sm next-sm :success)
+           (setq prev-sm st-mn)
+           )
+         (setq next-sm :success)
+         (send ,state-machine-name :add-transition prev-sm next-sm :success)
+         ,state-machine-name
+         )))))
+
+(defun demo (&optional (stages nil))
+  (make-hsm
+   fridge-demo
+   '((base-go-to-fridge-init-pose (:rarm :larm :rgripper :lgripper :torso))
+     (base-go-to-fridge (:base))
+     (open-fridge-door-initial-pose (:rarm :larm :rgripper :lgripper :torso :head))
+     (move-to-and-open-fridge-door (:base :rarm :rgripper))
+     (move-forward-larm (:larm))
+     (detach-fridge-handle (:larm :lgripper))
+     (swipe-fridge-door (:larm))
+     (grasp-can-posing (:rarm :larm :head))
+     (move-to-can-spot (:base))
+     (grasp-can-init (:rarm :larm :rgripper :lgripper :torso))
+     (grasp-can-motion (:larm :lgripper))
+     (go-back-from-fridge (:base))
+     (close-fridge (:rarm))
+     ))
+  (cond
+   (stages
+      (smach-exec-in-stages fridge-demo)
+      )
+   (t
+    (smach-exec fridge-demo)
+    )))
+
+(defun demo2 (&optional (stages nil))
+  (make-hsm
+   goto-fridge
+   '((base-go-to-fridge-init-pose  (:rarm :larm :rgripper :lgripper :torso))
+     (base-go-to-fridge (:base))
+     ))
+  (make-hsm
+   open-fridge-door
+   '((open-fridge-door-initial-pose (:rarm :larm :rgripper :lgripper :torso :head))
+     (move-to-and-open-fridge-door (:base :rarm :rgripper))
+     (move-forward-larm (:larm))
+     (detach-fridge-handle (:larm :lgripper))
+     (swipe-fridge-door (:larm))
+     (grasp-can-posing (:rarm :larm :head))
+     ))
+  (make-hsm
+   grasp-can
+   '((move-to-can-spot (:base))
+     (grasp-can-init (:rarm :larm :rgripper :lgripper :torso))
+     (grasp-can-motion (:larm :lgripper))
+     ))
+  (make-hsm
+   close
+   '((go-back-from-fridge (:base))
+     (close-fridge (:rarm))
+     ))
+  (make-hsm
+   fridge-demo
+   '(goto-fridge
+     open-fridge-door
+     grasp-can
+     close
+     ))
+  (cond
+   (stages
+      (smach-exec-in-stages fridge-demo)
+      )
+   (t
+    (smach-exec fridge-demo)
+    )))
+
+(defun demo3 (&optional (stages nil))
+  (make-hsm
+   fridge-demo
+   '((base-go-to-fridge-init-pose)
+;     (base-go-to-fridge)
+     (open-fridge-door-initial-pose)
+     (move-to-and-open-fridge-door)
+     (move-forward-larm)
+     (detach-fridge-handle)
+     (swipe-fridge-door)
+     (grasp-can-posing)
+     (move-to-can-spot)
+     (grasp-can-init)
+     (grasp-can-motion)
+     (go-back-from-fridge)
+     (close-fridge)
+     ))
+  (cond
+   (stages
+      (smach-exec-in-stages fridge-demo)
+      )
+   (t
+    (smach-exec fridge-demo)
+    )))
+
+(defun return-t (userdata)
+  (ros::ros-info "return-t func called")
+  )
+
+(defun demo4 (&optional (stages nil))
+  (make-hsm
+   fridge-demo
+   '((base-go-to-fridge-init-pose nil return-t)
+     (base-go-to-fridge nil return-t)
+     (open-fridge-door-initial-pose nil return-t)
+;     (look-at-fridge nil return-t)
+     (move-to-and-open-fridge-door nil return-t)
+     (move-forward-larm nil return-t)
+     (detach-fridge-handle nil return-t)
+     (swipe-fridge-door nil return-t)
+     (grasp-can-posing nil return-t)
+     (move-to-can-spot nil return-t)
+     (grasp-can-init nil return-t)
+     (grasp-can-motion nil return-t)
+     (go-back-from-fridge nil return-t)
+     (close-fridge nil return-t)
+     ))
+  (cond
+   (stages
+      (smach-exec-in-stages fridge-demo)
+      )
+   (t
+    (smach-exec fridge-demo)
+    )))
+
+(defun ppr2 ()
+  (load "package://pr2eus/pr2-interface.l")
+  (pr2-init)
+  )
+
+
+
+(warn "~%")
+(warn "~%")
+(warn "Caution######################################################~%")
+(warn "async-join-state class differs from original one.~%")
+(warn "actionlib-client-state function differs from original one.~%")
+(warn "smach-exec function differs from original one.~%")
+(warn "#############################################################~%")
+(warn "~%")
+(warn "~%")
+

--- a/detect_cans_in_fridge_201202/euslisp/base-go-to-fridge-init-pose.l
+++ b/detect_cans_in_fridge_201202/euslisp/base-go-to-fridge-init-pose.l
@@ -1,0 +1,35 @@
+
+(ros::load-ros-manifest "roseus_smach")
+(ros::roseus "base_go_to_fridge_init_pose_server")
+
+(defvar *dryrun* (ros::get-param "/dryrun"))
+(when (null *dryrun*)
+  (load "package://pr2eus/pr2-interface.l")
+  (load "package://jsk_demo_common/euslisp/pr2-move.l")
+  (pr2-init)
+  )
+
+(defun cb (server goal)
+  (ros::ros-info "base-go-to-fridge-init-pose callback func called")
+  (cond
+   (*dryrun*
+    )
+   (t
+    (base-go-to-fridge-init-pose) 
+     ))
+  (send server :set-succeeded (send server :result :value 1))
+  )
+
+(setq s (instance ros::simple-action-server :init
+                  "base_go_to_fridge_init_pose" roseus_smach::Sub5Action
+                  :execute-cb 'cb))
+
+(ros::rate 10)
+(do-until-key
+ (send s :worker)
+  (ros::spin-once)
+  (ros::sleep))
+
+(exit)
+
+

--- a/detect_cans_in_fridge_201202/euslisp/base-go-to-fridge.l
+++ b/detect_cans_in_fridge_201202/euslisp/base-go-to-fridge.l
@@ -1,0 +1,43 @@
+
+(ros::load-ros-manifest "roseus_smach")
+(ros::roseus "base_go_to_fridge_server")
+
+(defvar *dryrun* (ros::get-param "/dryrun"))
+(when (null *dryrun*)
+  (load "package://pr2eus/pr2-interface.l")
+  (load "package://jsk_demo_common/euslisp/pr2-move.l")
+  (pr2-init)
+  (if (send *ri* :simulation-modep)
+    (progn
+      (load "package://jsk_maps/src/eng2-scene.l")
+      (unless (boundp '*scene*) (setq *scene* (make-eng2-scene)))
+      (load "models/room73b2-scene.l")
+      (room73b2)
+      (send *ri* :objects (send *room73b2* :objects))
+      ))
+  )
+
+(defun cb (server goal)
+  (ros::ros-info "base-go-to-fridge callback func called" )
+  (cond
+   (*dryrun*
+    )
+   (t
+    (base-go-to-fridge)
+    ))
+  (send server :set-succeeded (send server :result))
+  )
+
+(setq s (instance ros::simple-action-server :init
+                  "base_go_to_fridge" roseus_smach::Sub5Action
+                  :execute-cb 'cb))
+
+(ros::rate 10)
+(do-until-key
+ (send s :worker)
+  (ros::spin-once)
+  (ros::sleep))
+
+(exit)
+
+

--- a/detect_cans_in_fridge_201202/euslisp/close-fridge.l
+++ b/detect_cans_in_fridge_201202/euslisp/close-fridge.l
@@ -1,0 +1,35 @@
+
+(ros::load-ros-manifest "roseus_smach")
+(ros::roseus "close_fridge_server")
+
+(defvar *dryrun* (ros::get-param "/dryrun"))
+(when (null *dryrun*)
+  (load "package://pr2eus/pr2-interface.l")
+  (load "package://jsk_demo_common/euslisp/pr2-action.l")
+  (pr2-init)
+  )
+
+(defun cb (server goal)
+  (ros::ros-info "close-fridge callback func called")
+  (cond
+   (*dryrun*
+    )
+   (t
+    (ros::ros-info "hoge")
+    (close-fridge :use-arm :larm)
+    ))
+  (send server :set-succeeded (send server :result))
+  )
+
+(setq s (instance ros::simple-action-server :init
+                  "close_fridge" roseus_smach::Sub5Action
+                  :execute-cb 'cb))
+
+(ros::rate 10)
+(do-until-key
+ (send s :worker)
+  (ros::spin-once)
+  (ros::sleep))
+
+(exit)
+

--- a/detect_cans_in_fridge_201202/euslisp/detach-fridge-handle.l
+++ b/detect_cans_in_fridge_201202/euslisp/detach-fridge-handle.l
@@ -1,0 +1,34 @@
+
+(ros::load-ros-manifest "roseus_smach")
+(ros::roseus "detach_fridge_handle_server")
+
+(defvar *dryrun* (ros::get-param "/dryrun"))
+(when (null *dryrun*)
+  (load "package://pr2eus/pr2-interface.l")
+  (load "package://jsk_demo_common/euslisp/pr2-action.l")
+  (pr2-init)
+  )
+
+(defun cb (server goal)
+  (ros::ros-info "detach-fridge-handle callback func called")
+  (cond
+   (*dryrun*
+    )
+   (t
+    (detach-fridge-handle)
+    ))
+  (send server :set-succeeded (send server :result))
+  )
+
+(setq s (instance ros::simple-action-server :init
+                  "detach_fridge_handle" roseus_smach::Sub5Action
+                  :execute-cb 'cb))
+
+(ros::rate 10)
+(do-until-key
+ (send s :worker)
+  (ros::spin-once)
+  (ros::sleep))
+
+(exit)
+

--- a/detect_cans_in_fridge_201202/euslisp/go-back-from-fridge.l
+++ b/detect_cans_in_fridge_201202/euslisp/go-back-from-fridge.l
@@ -1,0 +1,34 @@
+
+(ros::load-ros-manifest "roseus_smach")
+(ros::roseus "go_back_from_fridge_server")
+
+(defvar *dryrun* (ros::get-param "/dryrun"))
+(when (null *dryrun*)
+  (load "package://pr2eus/pr2-interface.l")
+  (load "package://jsk_demo_common/euslisp/pr2-action.l")
+  (pr2-init)
+  )
+
+(defun cb (server goal)
+  (ros::ros-info "go-back-from-fridge callback func called")
+  (cond
+   (*dryrun*
+    )
+   (t
+    (go-back-from-fridge :use-arm :larm :rotation -20)
+    ))
+  (send server :set-succeeded (send server :result))
+  )
+
+(setq s (instance ros::simple-action-server :init
+                  "go_back_from_fridge" roseus_smach::Sub5Action
+                  :execute-cb 'cb))
+
+(ros::rate 10)
+(do-until-key
+ (send s :worker)
+  (ros::spin-once)
+  (ros::sleep))
+
+(exit)
+

--- a/detect_cans_in_fridge_201202/euslisp/grasp-can-init.l
+++ b/detect_cans_in_fridge_201202/euslisp/grasp-can-init.l
@@ -1,0 +1,34 @@
+
+(ros::load-ros-manifest "roseus_smach")
+(ros::roseus "grasp_can_init_server")
+
+(defvar *dryrun* (ros::get-param "/dryrun"))
+(when (null *dryrun*)
+  (load "package://pr2eus/pr2-interface.l")
+  (load "package://jsk_demo_common/euslisp/pr2-action.l")
+  (pr2-init)
+  )
+
+(defun cb (server goal)
+  (ros::ros-info "grasp-can-init callback func called")
+  (cond
+   (*dryrun*
+    )
+   (t
+    (grasp-can-init)
+    ))
+  (send server :set-succeeded (send server :result))
+  )
+
+(setq s (instance ros::simple-action-server :init
+                  "grasp_can_init" roseus_smach::Sub5Action
+                  :execute-cb 'cb))
+
+(ros::rate 10)
+(do-until-key
+ (send s :worker)
+  (ros::spin-once)
+  (ros::sleep))
+
+(exit)
+

--- a/detect_cans_in_fridge_201202/euslisp/grasp-can-motion.l
+++ b/detect_cans_in_fridge_201202/euslisp/grasp-can-motion.l
@@ -1,0 +1,39 @@
+(setq *obj* (make-sphere 100)) ;; dummy object
+(setq *type* "georgia")
+
+(ros::load-ros-manifest "roseus_smach")
+(ros::roseus "grasp_can_motion_server")
+
+(defvar *dryrun* (ros::get-param "/dryrun"))
+(when (null *dryrun*)
+  (load "package://pr2eus/pr2-interface.l")
+  (load "package://jsk_demo_common/euslisp/pr2-action.l")
+  (pr2-init)
+  )
+
+(defun cb (server goal)
+  (ros::ros-info "grasp-can-motion callback func called")
+  (cond
+   (*dryrun*
+    )
+   (t
+    (let (isgrasp)
+    (dotimes (trial 10)
+      (setq isgrasp (grasp-can-motion :use-arm :larm :rotation -20))
+      (if isgrasp (return)))
+    )))
+  (send server :set-succeeded (send server :result))
+  )
+
+(setq s (instance ros::simple-action-server :init
+                  "grasp_can_motion" roseus_smach::Sub5Action
+                  :execute-cb 'cb))
+
+(ros::rate 10)
+(do-until-key
+ (send s :worker)
+  (ros::spin-once)
+  (ros::sleep))
+
+(exit)
+

--- a/detect_cans_in_fridge_201202/euslisp/grasp-can-posing.l
+++ b/detect_cans_in_fridge_201202/euslisp/grasp-can-posing.l
@@ -1,0 +1,34 @@
+
+(ros::load-ros-manifest "roseus_smach")
+(ros::roseus "grasp_can_posing_server")
+
+(defvar *dryrun* (ros::get-param "/dryrun"))
+(when (null *dryrun*)
+  (load "package://pr2eus/pr2-interface.l")
+  (load "package://jsk_demo_common/euslisp/pr2-action.l")
+  (pr2-init)
+  )
+
+(defun cb (server goal)
+  (ros::ros-info "grasp-can-posing callback func called")
+  (cond
+   (*dryrun*
+    )
+   (t
+    (grasp-can-posing :use-arm :larm)
+    ))
+  (send server :set-succeeded (send server :result))
+  )
+
+(setq s (instance ros::simple-action-server :init
+                  "grasp_can_posing" roseus_smach::Sub5Action
+                  :execute-cb 'cb))
+
+(ros::rate 10)
+(do-until-key
+ (send s :worker)
+  (ros::spin-once)
+  (ros::sleep))
+
+(exit)
+

--- a/detect_cans_in_fridge_201202/euslisp/look-at-fridge.l
+++ b/detect_cans_in_fridge_201202/euslisp/look-at-fridge.l
@@ -1,0 +1,34 @@
+
+(ros::load-ros-manifest "roseus_smach")
+(ros::roseus "lookat_fridge_server")
+
+(defvar *dryrun* (ros::get-param "/dryrun"))
+(when (null *dryrun*)
+  (load "package://pr2eus/pr2-interface.l")
+  (load "package://jsk_demo_common/euslisp/pr2-action.l")
+  (pr2-init)
+  )
+
+(defun cb (server goal)
+  (ros::ros-info "look-at-fridge callback func called")
+  (cond
+   (*dryrun*
+    )
+   (t
+    (look-at-fridge)
+    ))
+  (send server :set-succeeded (send server :result))
+  )
+
+(setq s (instance ros::simple-action-server :init
+                  "look_at_fridge" roseus_smach::Sub5Action
+                  :execute-cb 'cb))
+
+(ros::rate 10)
+(do-until-key
+ (send s :worker)
+  (ros::spin-once)
+  (ros::sleep))
+
+(exit)
+

--- a/detect_cans_in_fridge_201202/euslisp/move-forward-larm.l
+++ b/detect_cans_in_fridge_201202/euslisp/move-forward-larm.l
@@ -1,0 +1,34 @@
+
+(ros::load-ros-manifest "roseus_smach")
+(ros::roseus "move_forward_larm_server")
+
+(defvar *dryrun* (ros::get-param "/dryrun"))
+(when (null *dryrun*)
+  (load "package://pr2eus/pr2-interface.l")
+  (load "package://jsk_demo_common/euslisp/pr2-action.l")
+  (pr2-init)
+  )
+
+(defun cb (server goal)
+  (ros::ros-info "move-forward-larm callback func called")
+  (cond
+   (*dryrun*
+    )
+   (t
+    (move-forward-larm)
+    ))
+  (send server :set-succeeded (send server :result))
+  )
+
+(setq s (instance ros::simple-action-server :init
+                  "move_forward_larm" roseus_smach::Sub5Action
+                  :execute-cb 'cb))
+
+(ros::rate 10)
+(do-until-key
+ (send s :worker)
+  (ros::spin-once)
+  (ros::sleep))
+
+(exit)
+

--- a/detect_cans_in_fridge_201202/euslisp/move-to-and-open-fridge-door.l
+++ b/detect_cans_in_fridge_201202/euslisp/move-to-and-open-fridge-door.l
@@ -1,0 +1,37 @@
+
+(ros::load-ros-manifest "roseus_smach")
+(ros::roseus "move_to_and_open_fridge_door_server")
+
+(defvar *dryrun* (ros::get-param "/dryrun"))
+(when (null *dryrun*)
+  (load "package://pr2eus/pr2-interface.l")
+  (load "package://jsk_demo_common/euslisp/pr2-action.l")
+  (pr2-init)
+  )
+
+(defun cb (server goal)
+  (ros::ros-info "move-to-and-open-fridge-door callback func called")
+  (cond
+   (*dryrun*
+    )
+   (t
+    (dotimes (i 10 nil)
+      (setq ret (move-to-and-open-fridge-door))
+      (if ret (return))
+      )
+    ))
+  (send server :set-succeeded (send server :result))
+  )
+
+(setq s (instance ros::simple-action-server :init
+                  "move_to_and_open_fridge_door" roseus_smach::Sub5Action
+                  :execute-cb 'cb))
+
+(ros::rate 10)
+(do-until-key
+ (send s :worker)
+  (ros::spin-once)
+  (ros::sleep))
+
+(exit)
+

--- a/detect_cans_in_fridge_201202/euslisp/move-to-can-spot.l
+++ b/detect_cans_in_fridge_201202/euslisp/move-to-can-spot.l
@@ -1,0 +1,34 @@
+
+(ros::load-ros-manifest "roseus_smach")
+(ros::roseus "move_to_can_spot_server")
+
+(defvar *dryrun* (ros::get-param "/dryrun"))
+(when (null *dryrun*)
+  (load "package://pr2eus/pr2-interface.l")
+  (load "package://jsk_demo_common/euslisp/pr2-action.l")
+  (pr2-init)
+  )
+
+(defun cb (server goal)
+  (ros::ros-info "move-to-can-spot callback func called")
+  (cond
+   (*dryrun*
+    )
+   (t
+    (move-to-can-spot :use-arm :larm :rotation -20)
+    ))
+  (send server :set-succeeded (send server :result))
+  )
+
+(setq s (instance ros::simple-action-server :init
+                  "move_to_can_spot" roseus_smach::Sub5Action
+                  :execute-cb 'cb))
+
+(ros::rate 10)
+(do-until-key
+ (send s :worker)
+  (ros::spin-once)
+  (ros::sleep))
+
+(exit)
+

--- a/detect_cans_in_fridge_201202/euslisp/open-fridge-door-initial-pose.l
+++ b/detect_cans_in_fridge_201202/euslisp/open-fridge-door-initial-pose.l
@@ -1,0 +1,34 @@
+
+(ros::load-ros-manifest "roseus_smach")
+(ros::roseus "open_fridge-door_initial_pose_server")
+
+(defvar *dryrun* (ros::get-param "/dryrun"))
+(when (null *dryrun*)
+  (load "package://pr2eus/pr2-interface.l")
+  (load "package://jsk_demo_common/euslisp/pr2-action.l")
+  (pr2-init)
+  )
+
+(defun cb (server goal)
+  (ros::ros-info "open-fridge-door-initial-pose callback func called")
+  (cond
+   (*dryrun*
+    )
+   (t
+    (open-fridge-door-initial-pose)
+    ))
+  (send server :set-succeeded (send server :result))
+  )
+
+(setq s (instance ros::simple-action-server :init
+                  "open_fridge_door_initial_pose" roseus_smach::Sub5Action
+                  :execute-cb 'cb))
+
+(ros::rate 10)
+(do-until-key
+ (send s :worker)
+  (ros::spin-once)
+  (ros::sleep))
+
+(exit)
+

--- a/detect_cans_in_fridge_201202/euslisp/swipe-fridge-door.l
+++ b/detect_cans_in_fridge_201202/euslisp/swipe-fridge-door.l
@@ -1,0 +1,34 @@
+
+(ros::load-ros-manifest "roseus_smach")
+(ros::roseus "swipe_fridge_door_server")
+
+(defvar *dryrun* (ros::get-param "/dryrun"))
+(when (null *dryrun*)
+  (load "package://pr2eus/pr2-interface.l")
+  (load "package://jsk_demo_common/euslisp/pr2-action.l")
+  (pr2-init)
+  )
+
+(defun cb (server goal)
+  (ros::ros-info "swipe-fridge-handle callback func called")
+  (cond
+   (*dryrun*
+    )
+   (t
+    (swipe-fridge-door :use-arm :larm)
+    ))
+  (send server :set-succeeded (send server :result))
+  )
+
+(setq s (instance ros::simple-action-server :init
+                  "swipe_fridge_door" roseus_smach::Sub5Action
+                  :execute-cb 'cb))
+
+(ros::rate 10)
+(do-until-key
+ (send s :worker)
+  (ros::spin-once)
+  (ros::sleep))
+
+(exit)
+

--- a/detect_cans_in_fridge_201202/launch/fridge_demo.launch
+++ b/detect_cans_in_fridge_201202/launch/fridge_demo.launch
@@ -1,0 +1,51 @@
+<launch>
+  <arg name="main" default="false" />
+  <arg name="dry" default="false" />
+  <param name="dryrun" value="true" if="$(arg dry)"/>
+  <param name="dryrun" value="false" unless="$(arg dry)"/>
+
+  <node pkg="roseus" type="roseus" name="fridge_demo_main" output="screen" if="$(arg main)"
+        args="$(find detect_cans_in_fridge_201202)/euslisp/async-join-based-parallel-smach-main.l" />
+
+  <node pkg="roseus" type="roseus" name="goto_front_of_fridge" output="screen"
+        args="$(find detect_cans_in_fridge_201202)/euslisp/base-go-to-fridge-init-pose.l"  />
+
+  <node pkg="roseus" type="roseus" name="base_go_to_fridge" output="screen"
+        args="$(find detect_cans_in_fridge_201202)/euslisp/base-go-to-fridge.l"  />
+
+  <node pkg="roseus" type="roseus" name="open_fridge_door_initial_pose" output="screen"
+        args="$(find detect_cans_in_fridge_201202)/euslisp/open-fridge-door-initial-pose.l"  />
+
+  <node pkg="roseus" type="roseus" name="look_at_fridge" output="screen"
+        args="$(find detect_cans_in_fridge_201202)/euslisp/look-at-fridge.l"  />
+
+  <node pkg="roseus" type="roseus" name="move_to_and_open_fridge_door" output="screen"
+        args="$(find detect_cans_in_fridge_201202)/euslisp/move-to-and-open-fridge-door.l"  />
+
+  <node pkg="roseus" type="roseus" name="move_forward_larm" output="screen"
+        args="$(find detect_cans_in_fridge_201202)/euslisp/move-forward-larm.l"  />
+
+  <node pkg="roseus" type="roseus" name="detach_fridge_handle" output="screen"
+        args="$(find detect_cans_in_fridge_201202)/euslisp/detach-fridge-handle.l"  />
+
+  <node pkg="roseus" type="roseus" name="swipe_fridge_door" output="screen"
+        args="$(find detect_cans_in_fridge_201202)/euslisp/swipe-fridge-door.l"  />
+
+  <node pkg="roseus" type="roseus" name="grasp_can_posing" output="screen"
+        args="$(find detect_cans_in_fridge_201202)/euslisp/grasp-can-posing.l"  />
+
+  <node pkg="roseus" type="roseus" name="move_to_can_spot" output="screen"
+        args="$(find detect_cans_in_fridge_201202)/euslisp/move-to-can-spot.l"  />
+
+  <node pkg="roseus" type="roseus" name="grasp_can_init" output="screen"
+        args="$(find detect_cans_in_fridge_201202)/euslisp/grasp-can-init.l"  />
+
+  <node pkg="roseus" type="roseus" name="grasp_can_motion" output="screen"
+        args="$(find detect_cans_in_fridge_201202)/euslisp/grasp-can-motion.l"  />
+
+  <node pkg="roseus" type="roseus" name="go_back_from_fridge" output="screen"
+        args="$(find detect_cans_in_fridge_201202)/euslisp/go-back-from-fridge.l"  />
+
+  <node pkg="roseus" type="roseus" name="close_fridge" output="screen"
+        args="$(find detect_cans_in_fridge_201202)/euslisp/close-fridge.l"  />
+</launch>

--- a/jsk_demo_common/euslisp/pr2-action.l
+++ b/jsk_demo_common/euslisp/pr2-action.l
@@ -777,29 +777,6 @@
            (list 1200 600 1000 700))
      (send *ri* :stop-grasp :rarm)
      (send *ri* :wait-interpolation)
-
-     (case use-arm
-       (:rarm
-        ;; grasp rarm
-        (send *ri* :angle-vector (float-vector 130 5.30455 69.0 105.231 -88.5188 -69.9972 -5.72958 19.9717 31.3839 25.5029 23.0531 -118.916 160.305 -84.1469 160.058 -20 24) (* ratio 2000))
-        ;; (let ((cds (send *pr2* :rarm :end-coords :copy-worldcoords)))
-        ;;   ;; pre grasp pose
-        ;;   (send cds :rotate (- (deg2rad 20)) :z)
-        ;;   (send *pr2* :rarm :inverse-kinematics cds))
-        ;; (send *ri* :angle-vector (send *pr2* :angle-vector) 1400)
-        )
-       (:larm
-        ;; grasp larm
-        (send *ri* :angle-vector (float-vector 130 -32.3186 26.4366 -19.6876 -118.217 -138.147 -78.3509 -166.767 -5.30455 69.0 -105.231 -88.5188 69.9972 -5.72958 -19.9717 20.0 24.0) (* ratio 2000))
-        ;; (send *ri* :angle-vector-sequence
-        ;;       (list (float-vector 150.0 5.0 74.0 70.0 -75.0 -70.0 -6.0 20.0 -20.0 20.0 -34.0 -110.0 12.0 -38.0 74.0 -2.0 31.0)
-        ;;             ;;(float-vector 150.0 25.0 54.0 20.0 -120.0 -70.0 -6.0 20.0 -12.0 46.0 -79.0 -45.0 40.0 -22.0 27.0 -2.0 31.0)
-        ;;             (float-vector 150.0 25.0 54.0 20.0 -120.0 -70.0 -6.0 20.0 -22.0 66.0 -79.0 -65.0 -40.0 -72.0 27.0 -2.0 31.0)
-        ;;             (send *pr2* :angle-vector))
-        ;;       (list 1400 1200 800))
-        ;;         (send *ri* :start-grasp :rarm)
-        ))
-     (if wait (send *ri* :wait-interpolation))
      )
     ((:slide1 :slide2)
      (let ((rend (send *pr2* :rarm :end-coords :copy-worldcoords))
@@ -821,7 +798,36 @@
     ) ;; / (case door-type
   )
 
-
+(defun grasp-can-posing (&key (door-type :circle) (ratio 1) (use-arm :rarm) (wait t))
+  (case door-type
+        (:circle
+         (case use-arm
+               (:rarm
+                ;; grasp rarm
+                (send *ri* :angle-vector (float-vector 130 5.30455 69.0 105.231 -88.5188 -69.9972 -5.72958 19.9717 31.3839 25.5029 23.0531 -118.916 160.305 -84.1469 160.058 -20 24) (* ratio 2000))
+                ;; (let ((cds (send *pr2* :rarm :end-coords :copy-worldcoords)))
+                ;;   ;; pre grasp pose
+                ;;   (send cds :rotate (- (deg2rad 20)) :z)
+                ;;   (send *pr2* :rarm :inverse-kinematics cds))
+                ;; (send *ri* :angle-vector (send *pr2* :angle-vector) 1400)
+                )
+               (:larm
+                ;; grasp larm
+                (send *ri* :angle-vector (float-vector 130 -32.3186 26.4366 -19.6876 -118.217 -138.147 -78.3509 -166.767 -5.30455 69.0 -105.231 -88.5188 69.9972 -5.72958 -19.9717 20.0 24.0) (* ratio 2000))
+                ;; (send *ri* :angle-vector-sequence
+                ;;       (list (float-vector 150.0 5.0 74.0 70.0 -75.0 -70.0 -6.0 20.0 -20.0 20.0 -34.0 -110.0 12.0 -38.0 74.0 -2.0 31.0)
+                ;;             ;;(float-vector 150.0 25.0 54.0 20.0 -120.0 -70.0 -6.0 20.0 -12.0 46.0 -79.0 -45.0 40.0 -22.0 27.0 -2.0 31.0)
+                ;;             (float-vector 150.0 25.0 54.0 20.0 -120.0 -70.0 -6.0 20.0 -22.0 66.0 -79.0 -65.0 -40.0 -72.0 27.0 -2.0 31.0)
+                ;;             (send *pr2* :angle-vector))
+                ;;       (list 1400 1200 800))
+                ;;         (send *ri* :start-grasp :rarm)
+                ))
+         (if wait (send *ri* :wait-interpolation))
+         )
+        ((:slide1 :slide2)
+         ;; do nothing
+         )
+        ))
 
 (warn ";; define open-fridge-door")
 (defvar *fridge-distance-threshold* 25.0)
@@ -867,6 +873,9 @@
     ;;swipe fridge door by larm
     (swipe-fridge-door :door-type door-type :ratio ratio :use-arm use-arm :wait wait)
 
+    ;;grasp can posing
+    (grasp-can-posing :door-type door-type :ratio ratio :use-arm use-arm :wait wait)
+
     (send *ri* :ros-wait 0.0 :spin-self t) ;; attention-check ...
     (send *ri* :wait-interpolation)
     t
@@ -895,7 +904,7 @@
 (defun grasp-can-init ()
   (send *pr2* :head :neck-p :joint-angle 20)
   (send *pr2* :head :neck-y :joint-angle 23)
-  (send *ri* :angle-vector (send *pr2* :angle-vector) 2000)
+  (send *ri* :angle-vector (send *pr2* :angle-vector) 2000 :head-controller)
   )
 
 (defparameter *can-cds* nil)
@@ -950,6 +959,25 @@
     (return-from grasp-can-motion isgrasp)
     ))
 
+(defun go-back-from-fridge (&key (isgrasp t) (move t) (use-arm :rarm) (rotation 20))
+  (when isgrasp
+    (when move
+      (case use-arm
+        (:rarm
+         (send *ri* :go-pos-unsafe -0.3 0.05 (- rotation)))
+        (:larm
+         (send *ri* :go-pos-unsafe -0.3 -0.2 (- rotation)))))
+    (send *ri* :ros-wait 0.0 :spin-self t :spin t) ;; attention-check ...
+    (return-from go-back-from-fridge t))
+  ;; (unix::sleep 2)
+  (if (and (boundp '*use-voicetext*) *use-voicetext*)
+      (cond
+       ((and (boundp '*use-english*) *use-english*)
+        (speak-jp (format nil "I could no pick up ~A" *type*)))
+       (t (speak-jp (format nil "~Aを取り出しませんでした。" *type*))))
+    (speak-jp (format nil "~A を とりだし ません でした" *type*)))
+  nil
+  )
 
 (warn ";; define grasp-can")
 (defvar *use-arm-navigation* nil)
@@ -960,30 +988,15 @@
   (move-to-can-spot :use-arm use-arm :rotation rotation :move move :pre-move pre-move)
   (grasp-can-init)
   (when (not move-only)
-    (let (isgrasp)
+    (let (isgrasp res)
       ;; grasp can
       (unix:sleep 2)
       (dotimes (trial 10)
         (setq isgrasp (grasp-can-motion :use-arm use-arm :rotation rotation))
         (if isgrasp (return))
         )
-
-      (when isgrasp
-        (when move
-          (case use-arm
-            (:rarm
-             (send *ri* :go-pos-unsafe -0.3 0.05 (- rotation)))
-            (:larm
-             (send *ri* :go-pos-unsafe -0.3 -0.2 (- rotation)))))
-        (send *ri* :ros-wait 0.0 :spin-self t :spin t) ;; attention-check ...
-        (return-from grasp-can t))
-      ;; (unix::sleep 2)
-      (if (and (boundp '*use-voicetext*) *use-voicetext*)
-          (cond
-           ((and (boundp '*use-english*) *use-english*)
-            (speak-jp (format nil "I could no pick up ~A" *type*)))
-           (t (speak-jp (format nil "~Aを取り出しませんでした。" *type*))))
-        (speak-jp (format nil "~A を とりだし ません でした" *type*)))
+      (setq res (go-back-from-fridge :isgrasp isgrasp :move move :use-arm use-arm :rotation rotation))
+      (when res (return-from grasp-can t))
       )
     )
   (when (and move post-move)


### PR DESCRIPTION
#### async-join-based-structure-hazard-check-state-machine

* When you want to execute an action, async-join-based-structure-hazard-check-state-machine manages this action by managing 3 states (check, join, and exec state).

##### check state
* checks whether or not executing action is possible by considering structure hazard. If possible, transitions to exec state. If not possible, transitions to join state

##### join state
* wait until the actions ends

##### exec state
* execute the action.