### PR TITLE
pr2-action.l: apply reset-pose before open-fridge-func

### DIFF
--- a/jsk_demo_common/euslisp/pr2-action.l
+++ b/jsk_demo_common/euslisp/pr2-action.l
@@ -694,6 +694,14 @@
           (setq *last-fridge-handle* cds)
           ;; pr2 local coords transform to worldcoords
           (send cds :transform (send *pr2* :worldcoords) :world)
+          ;; keep head, torso and gripper, but start from reset-pose
+          (let ((prev-av (send *pr2* :angle-vector))
+                (hand-av))
+            (send *pr2* :reset-pose)
+            (setq hand-av (send *pr2* :rarm :angle-vector))
+            (send *pr2* :angle-vector prev-av)
+            (send *pr2* :rarm :angle-vector hand-av))
+          ;;
           (case door-type
             (:circle
              (setq ret (funcall open-fridge-func


### PR DESCRIPTION
move-to-and-open-fridgeの冷蔵庫のドアにてを近づけるドウサの前の姿勢で、reset-poseではなく肘がかなり内側に入った姿勢だと、その後のドアをあける動作列で手先の向きが正しくなくなってしまいます。

本質的な解法はhttps://github.com/jsk-ros-pkg/jsk_demos/blob/0.0.2/jsk_demo_common/euslisp/pr2-action.l#L390 でrotation-axis :z ではなくて、+-60度とかの指定を出きるようにすることかと思いました。