### PR TITLE
[detect_cans_in_fridge_201202/euslisp/main.l] bugfix: prevent calling (enable-behavior-server) many times

### DIFF
--- a/detect_cans_in_fridge_201202/euslisp/main.l
+++ b/detect_cans_in_fridge_201202/euslisp/main.l
@@ -175,6 +175,7 @@
               :finish-type finish-type)
        (return-from demo)))
     )
+  (enable-behavior-server)
   (if (eq app-manager :true) (ros::exit))
   )
 
@@ -215,8 +216,6 @@
        (ros::spin-once)
        (setq atype nil from nil)
        )
-     (unless atype
-       (enable-behavior-server))
      (ros::sleep))
     (ros::unsubscribe "/Tablet/StartDemo")
     (ros::unsubscribe "/Murase/Demo")


### PR DESCRIPTION
Applying this PR, `(enable-behavior-server)` is called only once after end of every demos
This fixes https://github.com/jsk-ros-pkg/jsk_demos/issues/1057