### PR TITLE
[detect_cans_in_fridge_201202/euslisp/match-hist.l] update parameter for match hist lower cutting threshold

### DIFF
--- a/detect_cans_in_fridge_201202/euslisp/match-hist.l
+++ b/detect_cans_in_fridge_201202/euslisp/match-hist.l
@@ -102,7 +102,7 @@
       ()))
   )
 
-(defun match-model (objs model-name &key (thr 0.7) (rotate 20))
+(defun match-model (objs model-name &key (thr 0.67) (rotate 20))
   (let ((histnum (ros::get-param "/object_hs_histgram/histnum"))
         (hs_bin (ros::get-param "/object_hs_histgram/hs_bin"))
         (model-hist (ros::get-param model-name))


### PR DESCRIPTION
sometimes stucks on retrying detect cans