### PR TITLE
Migrate srv files from jsk_pcl_ros to jsk_recognition_msgs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - ROSWS=wstool
     - BUILDER=catkin
   matrix:
-    - ROS_DISTRO=hydro  USE_DEB=true   NOT_TEST_INSTALL=true USE_JENKINS="true" EXTRA_DEB="ros-hydro-convex-decomposition ros-hydro-ivcon" CATKIN_PARALLEL_JOBS='-p1' ROS_PARALLEL_JOBS='-j1' CATKIN_PARALLEL_TEST_JOBS='-p1' ROS_PARALLEL_TEST_JOBS='-j1'
+    - ROS_DISTRO=hydro  USE_DEB=true   NOT_TEST_INSTALL=true USE_JENKINS="true" EXTRA_DEB="ros-hydro-convex-decomposition ros-hydro-ivcon" CATKIN_PARALLEL_JOBS='-p1' ROS_PARALLEL_JOBS='-j1' CATKIN_PARALLEL_TEST_JOBS='-p1' ROS_PARALLEL_TEST_JOBS='-j1' BEFORE_SCRIPT='$CI_SOURCE_PATH/.travis_before_script_hydro.bash'
     # - ROS_DISTRO=hydro  USE_DEB=false  NOT_TEST_INSTALL=true USE_JENKINS="true" EXTRA_DEB="ros-hydro-convex-decomposition ros-hydro-ivcon"
     - ROS_DISTRO=indigo USE_DEB=true   NOT_TEST_INSTALL=true EXTRA_DEB="ros-indigo-convex-decomposition ros-indigo-ivcon" CATKIN_PARALLEL_JOBS='-p8' ROS_PARALLEL_JOBS='-j8' CATKIN_PARALLEL_TEST_JOBS='-p8' ROS_PARALLEL_TEST_JOBS='-j8'
     # - ROS_DISTRO=indigo USE_DEB=false  NOT_TEST_INSTALL=true EXTRA_DEB="ros-indigo-convex-decomposition ros-indigo-ivcon"

--- a/.travis_before_script_hydro.bash
+++ b/.travis_before_script_hydro.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+sudo -H pip install -q rosinstall_generator
+
+rosinstall_generator --tar --rosdistro indigo \
+  jsk_recognition_msgs \
+>> /tmp/$$.rosinstall
+
+cd ~/ros/ws_$REPOSITORY_NAME/src
+wstool merge /tmp/$$.rosinstall
+wstool up -j1

--- a/detect_cans_in_fridge_201202/euslisp/detect_cans.l
+++ b/detect_cans_in_fridge_201202/euslisp/detect_cans.l
@@ -9,7 +9,7 @@
 
 (ros::roseus-add-msgs "pcl_msgs")
 (ros::roseus-add-srvs "jsk_perception")
-(ros::roseus-add-srvs "jsk_pcl_ros")
+(ros::roseus-add-srvs "jsk_recognition_msgs")
 (ros::roseus-add-msgs "posedetection_msgs")
 
 (defvar *topic-name* "/plane_extraction/output_nonplane_cloud") ;; point cloud from camera
@@ -128,7 +128,7 @@
 (defun euclidean-cluster-points (3dp &optional (tolerance 0.01))
   (when (or (not 3dp) (= (send 3dp :size) 0))
     (return-from euclidean-cluster-points nil))
-  (let ((req (instance jsk_pcl_ros::EuclideanSegmentRequest :init))
+  (let ((req (instance jsk_recognition_msgs::EuclideanSegmentRequest :init))
         ret)
     (send req :input (make-ros-msg-from-eus-pointcloud 3dp :with-color t))
     (send req :tolerance tolerance);;

--- a/detect_cans_in_fridge_201202/package.xml
+++ b/detect_cans_in_fridge_201202/package.xml
@@ -33,6 +33,7 @@
   <run_depend>roseus</run_depend>
   <run_depend>jsk_perception</run_depend>
   <run_depend>jsk_pcl_ros</run_depend>
+  <run_depend>jsk_recognition_msgs</run_depend>
   <run_depend>pr2_navigation_self_filter</run_depend>
   <run_depend>jsk_pr2_startup</run_depend>
   <run_depend>snap_map_icp</run_depend>

--- a/jsk_2011_07_pr2_semantic/euslisp/actions.l
+++ b/jsk_2011_07_pr2_semantic/euslisp/actions.l
@@ -4,7 +4,7 @@
 
 (ros::roseus-add-msgs "posedetection_msgs")
 (ros::roseus-add-msgs "pr2_gripper_sensor_msgs")
-(ros::roseus-add-srvs "jsk_pcl_ros")
+(ros::roseus-add-srvs "jsk_recognition_msgs")
 
 ;(ros::roseus "grasp_cup")
 
@@ -338,7 +338,7 @@
 	 (dotimes (i 5)
 	   (dotimes (j 5)
 	     (setq 2dpo (v+ 2dpos (float-vector (- (* i 10) 20) (- (* j 10) 20))))
-	     (setq req (instance jsk_pcl_ros::TransformScreenpointRequest :init
+	     (setq req (instance jsk_recognition_msgs::TransformScreenpointRequest :init
 				 :x (elt 2dpo 0) :y (elt 2dpo 1)))
 	     (setq res (ros::service-call ray_srv req))
 	     (setq 3dpos (ros::tf-point->pos (send res :point)))

--- a/jsk_2011_07_pr2_semantic/package.xml
+++ b/jsk_2011_07_pr2_semantic/package.xml
@@ -29,6 +29,7 @@
   <run_depend>json_prolog</run_depend>
   <run_depend>jsk_semantic_maps</run_depend>
   <run_depend>jsk_pcl_ros</run_depend>
+  <run_depend>jsk_recognition_msgs</run_depend>
   <run_depend>pr2eus_openrave</run_depend>
   <run_depend>pr2_gripper_sensor_action</run_depend>
 

--- a/jsk_2015_06_hrp_drc/drc_task_common/src/drc_task_common/manipulation_data_server.cpp
+++ b/jsk_2015_06_hrp_drc/drc_task_common/src/drc_task_common/manipulation_data_server.cpp
@@ -37,7 +37,7 @@
 #include <pcl/common/transforms.h>
 #include <pcl/filters/passthrough.h>
 #include <jsk_recognition_msgs/PointsArray.h>
-#include <jsk_pcl_ros/ICPAlignWithBox.h>
+#include <jsk_recognition_msgs/ICPAlignWithBox.h>
 #include <jsk_pcl_ros/pcl_conversion_util.h>
 #include <eigen_conversions/eigen_msg.h>
 #include <map>
@@ -248,7 +248,7 @@ public:
     _t_marker_box_pub = _node.advertise<jsk_recognition_msgs::BoundingBox>("/passed_selected_box", 1);
     _t_marker_information_pub = _node.advertise<drc_task_common::TMarkerInfo>("/t_marker_information", 1);
 		subscribe_cloud_and_box();
-    _icp_client = _node.serviceClient<jsk_pcl_ros::ICPAlignWithBox>("/icp_registration/icp_service");
+    _icp_client = _node.serviceClient<jsk_recognition_msgs::ICPAlignWithBox>("/icp_registration/icp_service");
     _get_type_client = _node.serviceClient<jsk_interactive_marker::GetType>("/transformable_interactive_server/get_type");
     _get_pose_client = _node.serviceClient<jsk_interactive_marker::GetTransformableMarkerPose>("/transformable_interactive_server/get_pose");
     _get_dim_client = _node.serviceClient<jsk_interactive_marker::GetMarkerDimensions>("/transformable_interactive_server/get_dimensions");
@@ -1234,7 +1234,7 @@ public:
     return true;
   }
   jsk_recognition_msgs::ICPResult request_icp(sensor_msgs::PointCloud2 *cloud_msg_ptr, jsk_recognition_msgs::BoundingBox *box_msg_ptr){
-    jsk_pcl_ros::ICPAlignWithBox srv; 
+    jsk_recognition_msgs::ICPAlignWithBox srv; 
     srv.request.target_cloud = *cloud_msg_ptr;
     srv.request.target_box = *box_msg_ptr;
     if (_icp_client.call(srv)){


### PR DESCRIPTION
## Background

Some packages in jsk_visualization depends on jsk_pcl_ros because it uses the srv files.
But jsk_pcl_ros is a very large package and the dependency should be avoided ideally.
The solution is placing `msg/srv` files into `jsk_recognition_msgs`.

## Plans

1. Merge this after `jsk_recognition_msgs` is released: http://repositories.ros.org/status_page/ros_indigo_default.html?q=jsk_recognition_msgs
1. Release this pacakge.
1. Remove `jsk_pcl_ros/srv`.
1. Release `jsk_pcl_ros`.

## Related PRs

- https://github.com/jsk-ros-pkg/jsk_recognition/pull/1827
- https://github.com/jsk-ros-pkg/jsk_recognition/pull/1914