### PR TITLE
[drc_task_common/package.xml] Add rviz_animated_view_controller to ru…

### DIFF
--- a/jsk_2015_06_hrp_drc/drc_task_common/package.xml
+++ b/jsk_2015_06_hrp_drc/drc_task_common/package.xml
@@ -92,6 +92,7 @@
   <run_depend>smach_msgs</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>checkerboard_detector</run_depend>
+  <run_depend>rviz_animated_view_controller</run_depend>
   <export>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
   </export>


### PR DESCRIPTION
…n_depends

#1215 でのご指摘の通りにrun_dependsに入れました。
確認方法が正しいか解りませんが、rviz_animated_view_controllerが入ってないコンピュータで次のように試してみたところ、インストール出来ました。

```
 ➜  drc_task_common git:(016200c) ✗ rosdep install --from-paths . --ignore-src --rosdistro indigo
executing command [sudo -H apt-get install ros-indigo-rviz-animated-view-controller]
[sudo] password for tamura: 
パッケージリストを読み込んでいます... 完了
依存関係ツリーを作成しています                
状態情報を読み取っています... 完了
以下の特別パッケージがインストールされます:
  ros-indigo-view-controller-msgs
以下のパッケージが新たにインストールされます:
  ros-indigo-rviz-animated-view-controller ros-indigo-view-controller-msgs
アップグレード: 0 個、新規インストール: 2 個、削除: 0 個、保留: 408 個。
82.3 kB のアーカイブを取得する必要があります。
この操作後に追加で 504 kB のディスク容量が消費されます。
続行しますか? [Y/n] y
取得:1 http://packages.ros.org/ros/ubuntu/ trusty/main ros-indigo-view-controller-msgs amd64 0.1.2-0trusty-20170313-091915-0700 [15.0 kB]
取得:2 http://packages.ros.org/ros/ubuntu/ trusty/main ros-indigo-rviz-animated-view-controller amd64 0.1.1-0trusty-20170327-231529-0700 [67.2 kB]
82.3 kB を 1秒 で取得しました (56.1 kB/s)                          
以前に未選択のパッケージ ros-indigo-view-controller-msgs を選択しています。
(データベースを読み込んでいます ... 現在 381659 個のファイルとディレクトリがインストールされています。)
.../ros-indigo-view-controller-msgs_0.1.2-0trusty-20170313-091915-0700_amd64.deb を展開する準備をしています ...
ros-indigo-view-controller-msgs (0.1.2-0trusty-20170313-091915-0700) を展開しています...
以前に未選択のパッケージ ros-indigo-rviz-animated-view-controller を選択しています。
.../ros-indigo-rviz-animated-view-controller_0.1.1-0trusty-20170327-231529-0700_amd64.deb を展開する準備をしています ...
ros-indigo-rviz-animated-view-controller (0.1.1-0trusty-20170327-231529-0700) を展開しています...
ros-indigo-view-controller-msgs (0.1.2-0trusty-20170313-091915-0700) を設定しています ...
ros-indigo-rviz-animated-view-controller (0.1.1-0trusty-20170327-231529-0700) を設定しています ...
#All required rosdeps installed successfully
```