### PR TITLE
[jsk_demo_common] some bugfix

### DIFF
--- a/jsk_demo_common/euslisp/pr2-action.l
+++ b/jsk_demo_common/euslisp/pr2-action.l
@@ -376,6 +376,24 @@
     ;; finalize
     *ret*))
 
+(defun move-arm ;;TODO::choose openrave or eus
+  (arm coords &rest args &key (move-robot t) (wait-interpolation t) (rotation-axis :z) (debug nil)
+       (sec 2000) (use-torso 0.005) (record-ik nil) &allow-other-keys)
+  (unless
+      (send* *pr2* :inverse-kinematics coords :move-arm arm :rotation-axis rotation-axis
+             :use-torso use-torso
+             :revert-if-fail nil :debug-view debug args)
+    (when record-ik
+      (setq *ik-fail-av*  (send *pr2* :angle-vector))
+      (setq *ik-fail-coords*  (send coords :copy-worldcoords))
+      (dump-loadable-structure (format nil "ik-fail-~d.l" (send (ros::time-now) :to-sec))
+                               *ik-fail-coords* *ik-fail-av*))
+    (return-from move-arm nil))
+  (when move-robot
+    (send *ri* :angle-vector (send *pr2* :angle-vector) sec)
+    (when wait-interpolation (send *ri* :wait-interpolation)))
+  t)
+
 (defun move-fridge-traj (hand cds-traj
                               ;; &key ((:rotation-axis ra) :z) (use-torso 0.0025)
                               &key ((:rotation-axis ra) :z) (use-torso nil)

--- a/jsk_demo_common/euslisp/pr2-action.l
+++ b/jsk_demo_common/euslisp/pr2-action.l
@@ -278,8 +278,8 @@
   (send *ri* :wait-interpolation))
 
 (defun generate-slide-path
-  "originally defined at jsk_smart_gui/src/utils.l"
   (start-point point1 point2 path-length &key (div 10))
+  "originally defined at jsk_smart_gui/src/utils.l"
   (let* ((di (normalize-vector (v- point2 point1)))
          (ln (make-line point1 point2))
          (fp (send ln :point (send ln :foot start-point))))
@@ -293,8 +293,8 @@
       (nreverse ret))))
 
 (defun generate-circle-path
-  "originally defined at jsk_smart_gui/src/utils.l"
   (start-point point1 point2 angle &key (div 20))
+  "originally defined at jsk_smart_gui/src/utils.l"
   (let* ((axis (normalize-vector (v- point1 point2)))
    (ln (make-line point1 point2))
    (fp (send ln :point (send ln :foot start-point))))

--- a/jsk_demo_common/euslisp/pr2-attention-action.l
+++ b/jsk_demo_common/euslisp/pr2-attention-action.l
@@ -377,6 +377,24 @@
     ;; finalize
     *ret*))
 
+(defun move-arm ;;TODO::choose openrave or eus
+  (arm coords &rest args &key (move-robot t) (wait-interpolation t) (rotation-axis :z) (debug nil)
+       (sec 2000) (use-torso 0.005) (record-ik nil) &allow-other-keys)
+  (unless
+      (send* *pr2* :inverse-kinematics coords :move-arm arm :rotation-axis rotation-axis
+             :use-torso use-torso
+             :revert-if-fail nil :debug-view debug args)
+    (when record-ik
+      (setq *ik-fail-av*  (send *pr2* :angle-vector))
+      (setq *ik-fail-coords*  (send coords :copy-worldcoords))
+      (dump-loadable-structure (format nil "ik-fail-~d.l" (send (ros::time-now) :to-sec))
+                               *ik-fail-coords* *ik-fail-av*))
+    (return-from move-arm nil))
+  (when move-robot
+    (send *ri* :angle-vector (send *pr2* :angle-vector) sec)
+    (when wait-interpolation (send *ri* :wait-interpolation)))
+  t)
+
 (defun move-fridge-traj (hand cds-traj
                               ;; &key ((:rotation-axis ra) :z) (use-torso 0.0025)
                               &key ((:rotation-axis ra) :z) (use-torso nil)

--- a/jsk_demo_common/euslisp/pr2-attention-action.l
+++ b/jsk_demo_common/euslisp/pr2-attention-action.l
@@ -279,8 +279,8 @@
   (send *ri* :wait-interpolation))
 
 (defun generate-slide-path
-  "originally defined at jsk_smart_gui/src/utils.l"
   (start-point point1 point2 path-length &key (div 10))
+  "originally defined at jsk_smart_gui/src/utils.l"
   (let* ((di (normalize-vector (v- point2 point1)))
          (ln (make-line point1 point2))
          (fp (send ln :point (send ln :foot start-point))))
@@ -294,8 +294,8 @@
       (nreverse ret))))
 
 (defun generate-circle-path
-  "originally defined at jsk_smart_gui/src/utils.l"
   (start-point point1 point2 angle &key (div 20))
+  "originally defined at jsk_smart_gui/src/utils.l"
   (let* ((axis (normalize-vector (v- point1 point2)))
    (ln (make-line point1 point2))
    (fp (send ln :point (send ln :foot start-point))))


### PR DESCRIPTION
- `generate-slide-path`, `generate-circle-path`: docstring should after function definition
- add missing `move-arm` function

Special thanks to @asilx !

BTW, why demos have worked well without this fix...?