### PR TITLE
jsk_maps: add fetch dock spot to map

### DIFF
--- a/jsk_maps/src/eng2-scene.l
+++ b/jsk_maps/src/eng2-scene.l
@@ -216,6 +216,9 @@
          `(:rot ,(rpy-matrix 0 0 0)
                 :pos ,(float-vector -750.0 6829.0 51.6065)
                 :name "/eng2/7f/room73A3-front1")
+   `(:rot ,(rpy-matrix pi/2 0 0)
+     :pos ,(float-vector 6800 6000 0)
+     :name "/eng2/7f/room73B2-fetch-dock-front")
 
 
 


### PR DESCRIPTION
This PR adds `dock` spot for fetch robot.

Currently, the map is not clean at 73B2, but @708yamaguchi will update the map to the latest soon.

![dock map](https://user-images.githubusercontent.com/1901008/34820625-6f1a97e0-f704-11e7-82d8-7371d27d09f2.png)
