### PR TITLE
Add fetch's dock spot to /spots_marker_array

### DIFF
--- a/jsk_maps/src/eng2-scene.l
+++ b/jsk_maps/src/eng2-scene.l
@@ -216,6 +216,9 @@
          `(:rot ,(rpy-matrix 0 0 0)
                 :pos ,(float-vector -750.0 6829.0 51.6065)
                 :name "/eng2/7f/room73A3-front1")
+	 `(:rot ,(rpy-matrix pi/2 0 0)
+			:pos ,(float-vector 2082 7827 51.6065)
+			:name "/eng2/7f/room73B2-fetch-dock-front")
 
 
 


### PR DESCRIPTION
This is updated version of https://github.com/jsk-ros-pkg/jsk_demos/pull/1232.
Recently, position of fetch's dock was changed.