### PR TITLE
jsk_2013_04_pr2_610: disable task_compiler required on test

### DIFF
--- a/jsk_2013_04_pr2_610/launch/planner.launch
+++ b/jsk_2013_04_pr2_610/launch/planner.launch
@@ -1,6 +1,8 @@
 <launch>
   <arg name="debug" default="false" />
   <arg name="use_ffha" default="false" />
+  <arg name="exit_on_finish" default="true" doc="exit on the end of task performance if enabled"/>
+
   <node pkg="pddl_planner_viewer"
         type="pddl_planner_viewer.py"
         name="$(anon pddl_planner_viewer)" />
@@ -28,6 +30,7 @@
                                       lazy_wastar([hff,hlm],preferred=[hff,hlm],w=2)],
                                       repeat_last=false)&quot;" />
     <arg name="debug" value="$(arg debug)" />
+    <arg name="exit_on_finish" value="$(arg exit_on_finish)"/>
   </include>
   </group>
 </launch>

--- a/jsk_2013_04_pr2_610/package.xml
+++ b/jsk_2013_04_pr2_610/package.xml
@@ -25,7 +25,7 @@
   <build_depend>roseus_smach</build_depend>
   <build_depend>jsk_demo_common</build_depend>
   <build_depend>jsk_perception</build_depend>
-  <build_depend>task_compiler</build_depend>
+  <build_depend version_gte="0.1.12">task_compiler</build_depend>
   <build_depend>pddl_planner</build_depend>
   <build_depend>pddl_planner_viewer</build_depend>
   <build_depend>laser_filters_jsk_patch</build_depend>
@@ -36,7 +36,7 @@
   <run_depend>jsk_perception</run_depend>
   <run_depend>pddl_planner</run_depend>
   <run_depend>pddl_planner_viewer</run_depend>
-  <run_depend>task_compiler</run_depend>
+  <run_depend version_gte="0.1.12">task_compiler</run_depend>
   <run_depend>laser_filters_jsk_patch</run_depend>
   <run_depend>roseus</run_depend>
   <run_depend>pr2eus</run_depend>

--- a/jsk_2013_04_pr2_610/test/test-demo-plan.test
+++ b/jsk_2013_04_pr2_610/test/test-demo-plan.test
@@ -16,5 +16,6 @@
                                       repeat_last=false)&quot;" />
     <arg name="debug" value="true" />
     <arg name="gui" value="false" />
+    <arg name="exit_on_finish" value="false"/>
   </include>
 </launch>


### PR DESCRIPTION
Add option `exit_on_finish`.
Assumes that https://github.com/jsk-ros-pkg/jsk_planning/pull/67 is released in the next version.