### PR TITLE
udpate to jsk_travis 0.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,11 @@ env:
     - ROS_DISTRO=indigo    DOCKER_RUN_OPTION='--rm -e TEST_ROBOT=pr2'   TEST_PKGS="detect_cans_in_fridge_201202 elevator_move_base_pr2 interactive_behavior_201409 jsk_2011_07_pr2_semantic jsk_2013_04_pr2_610 jsk_demo_common jsk_maps"
     - ROS_DISTRO=indigo    DOCKER_RUN_OPTION='--rm -e TEST_ROBOT=fetch' TEST_PKGS="jsk_2017_10_semi jsk_maps"
     - ROS_DISTRO=kinetic
+    - ROS_DISTRO=melodic
 matrix:
   fast_finish: true
   allow_failures:
-    - env: ROS_DISTRO=indigo
-    - env: ROS_DISTRO=kinetic
+    - env: ROS_DISTRO=melodic
 before_script:
   - if [[ "$ROS_DISTRO" == "indigo" && "$DOCKER_IMAGE_JENKINS" == "" ]]; then export export DOCKER_IMAGE_JENKINS='ros-ubuntu:14.04-pcl'; fi
   - if [[ "$ROS_DISTRO" == "kinetic" && "$DOCKER_IMAGE_JENKINS" == "" ]]; then export export DOCKER_IMAGE_JENKINS='ros-ubuntu:16.04-pcl'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,8 @@ matrix:
   allow_failures:
     - env: ROS_DISTRO=indigo
     - env: ROS_DISTRO=kinetic
+before_script:
+  - if [[ "$ROS_DISTRO" == "indigo" && "$DOCKER_IMAGE_JENKINS" == "" ]]; then export export DOCKER_IMAGE_JENKINS='ros-ubuntu:14.04-pcl'; fi
+  - if [[ "$ROS_DISTRO" == "kinetic" && "$DOCKER_IMAGE_JENKINS" == "" ]]; then export export DOCKER_IMAGE_JENKINS='ros-ubuntu:16.04-pcl'; fi
+  - if [[ "$ROS_DISTRO" == "melodic" && "$DOCKER_IMAGE_JENKINS" == "" ]]; then export export DOCKER_IMAGE_JENKINS='ros-ubuntu:18.04-pcl'; fi
 script: source .travis/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: ROS_DISTRO=kinetic # need to wait for https://github.com/jsk-ros-pkg/jsk_recognition/pull/2414 and https://github.com/jsk-ros-pkg/jsk_demos/pull/1266/commits/c90dd49aeff8a4b8849787cfd57ae3bf504d3a53
     - env: ROS_DISTRO=melodic
 before_script:
   - if [[ "$ROS_DISTRO" == "indigo" && "$DOCKER_IMAGE_JENKINS" == "" ]]; then export export DOCKER_IMAGE_JENKINS='ros-ubuntu:14.04-pcl'; fi

--- a/jsk_2013_04_pr2_610/CMakeLists.txt
+++ b/jsk_2013_04_pr2_610/CMakeLists.txt
@@ -6,12 +6,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   jsk_demo_common
   jsk_perception
-  task_compiler
   pddl_planner
-  pddl_planner_viewer
-  laser_filters_jsk_patch
-  imagesift
-  pr2eus
   roseus_smach
   roseus)
 

--- a/jsk_2013_04_pr2_610/package.xml
+++ b/jsk_2013_04_pr2_610/package.xml
@@ -41,6 +41,7 @@
   <run_depend>roseus</run_depend>
   <run_depend>pr2eus</run_depend>
   <run_depend>roseus_smach</run_depend>
+  <run_depend>smach_viewer</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>imagesift</run_depend>
   <run_depend>sound_play</run_depend>


### PR DESCRIPTION
- set kinetic as allow failure
- add run_depend smach_viewr to jsk_2013_04_pr2_610

    ```
    [/workspace/ros/ws_jsk_demos/src/jsk_demos/jsk_2013_04_pr2_610/launch/planner.launch]:
    Missing package dependencies: task_compiler/package.xml: smach_viewer
    cannot find package [smach_viewer] for node [smach_viewer.py] unable to
    find node [smach_viewer/smach_viewer.py]: smach_viewer ROS path
    [0]=/opt/ros/kinetic/share/ros
    ```
    https://github.com/tork-a/jsk_planning-release/blob/release/kinetic/task_compiler/package.xml#L25

- add melodic test and remove indigo/kinetic from allow_failures
- remove unnecessary packages from find_package, remaining package lists are used in generate_mesages
- update jsk_travis to 0.5.0

- set kinetic as a allow failure
    need to wait for https://github.com/jsk-ros-pkg/jsk_recognition/pull/2414 and https://github.com/jsk-ros-pkg/jsk_demos/pull/1266/commits/c90dd49aeff8a4b8849787cfd57ae3bf504d3a53
