### PR TITLE
[rwt_teleop] fix typo in rwt_teleop.app

### DIFF
--- a/rwt_teleop/apps/rwt_teleop/rwt_teleop.app
+++ b/rwt_teleop/apps/rwt_teleop/rwt_teleop.app
@@ -39,8 +39,8 @@ plugins:
       video_decompressed_topic_name: /edgetpu_human_pose_estimator/rwt_teleop/output/image
       video_height: 480
       video_width: 640
-      video_framerate: 15
-      video_encoding: RGB
+      video_framerate: 10
+      video_encoding: BGR
   - name: rosbag_recorder_plugin
     type: app_recorder/rosbag_recorder_plugin
     launch_args:


### PR DESCRIPTION
sorry, but there is a commit which is not included in #1337 .
this PR fix typo in `rwt_teleop`.
This PR is now running in PR1040.