### PR TITLE
remove roseus find_package in welcome_to_jsk_fetch

### DIFF
--- a/welcome_to_jsk_fetch/CMakeLists.txt
+++ b/welcome_to_jsk_fetch/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(welcome_to_jsk_fetch)
 
-find_package(catkin REQUIRED
-    roseus # required in indigo
-)
+find_package(catkin REQUIRED)
 
 catkin_package()


### PR DESCRIPTION
pr1040 build failure in `welcome_to_jsk_fetch`.

```
______________________________________________________________________________________________________________
Errors << welcome_to_jsk_fetch:cmake /home/applications/ros/indigo/logs/welcome_to_jsk_fetch/build.cmake.001.log
-- set EUSDIR to /home/applications/ros/indigo/devel/share/euslisp/jskeus/eus
-- set ARCHDIR to Linux64
CMake Error at /home/applications/ros/indigo/devel/share/jsk_robot_startup/cmake/jsk_robot_startupConfig.cmake:141 (message):
  Project 'welcome_to_jsk_fetch' tried to find library 'jsk_robot_startup'.
  The library is neither a target nor built/installed properly.  Did you
  compile project 'jsk_robot_startup'? Did you find_package() it before the
  subdirectory containing its code is included?
Call Stack (most recent call first):
  /home/applications/ros/indigo/src/jsk-ros-pkg/jsk_roseus/roseus/cmake/roseus.cmake:93 (find_package)
  /home/applications/ros/indigo/src/jsk-ros-pkg/jsk_roseus/roseus/cmake/roseus.cmake:174 (generate_all_roseus_messages)
  /home/applications/ros/indigo/devel/share/roseus/cmake/roseusConfig.cmake:190 (include)
  /opt/ros/indigo/share/catkin/cmake/catkinConfig.cmake:76 (find_package)
  CMakeLists.txt:4 (find_package)


cd /home/applications/ros/indigo/build/welcome_to_jsk_fetch; catkin build --get-env welcome_to_jsk_fetch | catkin env -si  /usr/bin/cmake /home/applications/ros/indigo/src/jsk-ros-pkg/jsk_demos/welcome_to_jsk_fetch --no-warn-unused-cli -DCATKIN_DEVEL_PREFIX=/home/applications/ros/indigo/devel/.private/welcome_to_jsk_fetch -DCMAKE_INSTALL_PREFIX=/home/applications/ros/indigo/install -DCMAKE_BUILD_TYPE=Release; cd -

..............................................................................................................
Failed << welcome_to_jsk_fetch:cmake                          [ Exited with code 1 ]                          
Failed <<< welcome_to_jsk_fetch  
```