### PR TITLE
[jsk_maps] rename start_empty_map.launch and standardize as other map launch

### DIFF
--- a/jsk_maps/launch/start_empty_map.launch
+++ b/jsk_maps/launch/start_empty_map.launch
@@ -1,7 +1,0 @@
-<launch>
-  <!-- create empty map -->
-  <node name="$(anon empty_map_server)" pkg="map_server" type="map_server"
-        args="$(find jsk_maps)/raw_maps/empty_map.yaml" >
-    <param name="frame_id" value="/map"/>
-  </node>
-</launch>

--- a/jsk_maps/launch/start_empty_map.launch
+++ b/jsk_maps/launch/start_empty_map.launch
@@ -1,0 +1,1 @@
+start_map_empty_world.launch

--- a/jsk_maps/launch/start_map_empty_world.launch
+++ b/jsk_maps/launch/start_map_empty_world.launch
@@ -1,0 +1,16 @@
+<launch>
+  <arg name="launch_map_server" default="true" />
+
+  <!-- unused args; add them to keep the same args as other launches -->
+  <arg name="MACHINE" default="localhost" />
+  <arg name="use_machine" default="false" />
+  <arg name="use_pictogram" default="false" />
+  <arg name="keepout" default="false" />
+
+  <!-- create empty map -->
+  <node if="$(arg launch_map_server)"
+        name="$(anon empty_map_server)" pkg="map_server" type="map_server"
+        args="$(find jsk_maps)/raw_maps/empty_map.yaml" >
+    <param name="frame_id" value="/map"/>
+  </node>
+</launch>


### PR DESCRIPTION
rename `start_empty_map.launch` to `start_map_empty_world.launch` in order to standardize as other map launch.
other map launches' name are `start_map_[eng2|eng8].launch`, so the launch for `empty_world` should be `start_map_empty_world.launch`. 
the file name rule is used to launch in `pr2.launch` and `fetch_bringup.launch`.
I add symbolic link to keep the old filename launch, too.

https://github.com/jsk-ros-pkg/jsk_robot/blob/5c3fce88184e953ba753c83b53bdb07c806771eb/jsk_pr2_robot/jsk_pr2_startup/pr2.launch#L62

https://github.com/jsk-ros-pkg/jsk_robot/blob/5c3fce88184e953ba753c83b53bdb07c806771eb/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch#L185