### PR TITLE
[jsk_2013_04_pr2_610] Fix installation README

### DIFF
--- a/jsk_2013_04_pr2_610/README.md
+++ b/jsk_2013_04_pr2_610/README.md
@@ -54,7 +54,7 @@ mkdir ~/ros/jsk_demo_ws/src -p
 cd ~/ros/jsk_demo_ws
 catkin init
 wstool init src
-wstool merge https://raw.githubusercontent.com/jsk-ros-pkg/jsk_demos/master/jsk_2013_04_pr2_610/jsk_2013_04_pr2_610.rosinstall
+wstool merge -t src https://raw.githubusercontent.com/jsk-ros-pkg/jsk_demos/master/jsk_2013_04_pr2_610/jsk_2013_04_pr2_610.rosinstall
 wstool update -t src
 rosdep install --from-paths src --ignore-src -r -n -y
 catkin build jsk_2013_04_pr2_610


### PR DESCRIPTION
I was trying to do the installation and got the following error output.

```
$ wstool merge https://raw.githubusercontent.com/jsk-ros-pkg/jsk_demos/master/jsk_2013_04_pr2_610/jsk_2013_04_pr2_610.rosinstall
ERROR in config: Command requires a target workspace.
```

This PR avoids this error by adding the `-t src` option.
The `-t src` option is also used for Github Action CI.
https://github.com/jsk-ros-pkg/jsk_demos/blob/74a2c31203af453150a1ea9d159ff5b76dd35179/.travis.before_script.sh#L12

FYI: The following is a ROS Answer that solves a similar problem.
https://answers.ros.org/question/191130/error-in-catkin_ws/